### PR TITLE
Two additional options

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -42,6 +42,10 @@ alwaysLookforSplitBrackets: 1
 # in LaTeX) and do not introduce it
 removeTrailingWhitespace: 0
 
+# treat commented lines specifically: keep indentation, but stack consecutive
+# comment symbols (%) and allow at max one space behind each bunch
+treatComments: 0
+
 # environments that have tab delimiters, add more 
 # as needed
 lookForAlignDelims:


### PR DESCRIPTION
Dear Mr. Hughes,

I implemented two new options, that were missing for my purposes, in `latexindent.pl`. I did not yet adapt the manual, but you'll find my proposed texts in the commit messages.

The first new option, `removeTrailingWhitespace`, does what it says. This is especially useful, when one keeps his documents in a VCS. The implementation in this case is hopefully pretty clean, although I am illiterate in perl.

The second option, `treatComments`,  is a dirty hack (at least in comparison). So you might want to review my implementation more carefully. Its purpose is to avoid having lines like this one

``` latex
    %   %   %       %   %   \item
```

which may appear after repeated application of `latexindent.pl` and commenting/uncommenting lines.

Finally, as now I have the chance to do so, I want to thank you for developing this script, which already helped me a lot!

Best wishes,

Michel Voßkuhle
