### PR TITLE
Implemented `removeTrailingWhitespace` option

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -38,6 +38,10 @@ alwaysLookforSplitBraces: 1
 # have to complete checkunmatchedbracket
 alwaysLookforSplitBrackets: 1
 
+# remove trailing whitespace from all lines (this should be a secure operation
+# in LaTeX) and do not introduce it
+removeTrailingWhitespace: 0
+
 # environments that have tab delimiters, add more 
 # as needed
 lookForAlignDelims:


### PR DESCRIPTION
The manual has not yet been adapted. Proposed addition:

``` latex
\item[\verbitem{removeTrailingWhitespace}] \lstinline!0!

By default \lstinline!latexindent.pl! indents every line --also empty lines--
thus creating `trailing whitespace' feared by most version control systems. If
this option is set to \lstinline!1!, trailing whitespace is removed from all
lines, also non-empty ones. In general this should not create any problems, but
by precaution this option is turned off by default.
```

Signed-off-by: Michel Vosskuhle m.vosskuhle@uni-muenster.de
