### PR TITLE
Changed indentconfig.yaml for .latexindentconfig.yaml

### DIFF
--- a/latexindent.pl
+++ b/latexindent.pl
@@ -293,7 +293,7 @@ else
 
 if ( -e $indentconfig and !$onlyDefault )
 {
-      print $logfile "Reading path information from $indentconfig\n";
+      print $logfile "Reading path information from ",File::HomeDir->my_home,"/indentconfig.yaml\n";
       print $logfile "Only default settings requested, not reading USER settings from $indentconfig\n";
 
       # read the absolute paths from indentconfig.yaml

--- a/latexindent.pl
+++ b/latexindent.pl
@@ -23,7 +23,7 @@ my @listOfModules = ('FindBin','YAML::Tiny','File::Copy','File::Basename','Getop
 # check the other modules are available
 foreach my $moduleName (@listOfModules)
 {
-    # references: 
+    # references:
     #       http://stackoverflow.com/questions/251694/how-can-i-check-if-i-have-a-perl-module-before-using-it
     #       http://stackoverflow.com/questions/1917261/how-can-i-dynamically-include-perl-modules-without-using-eval
     eval {
@@ -86,7 +86,7 @@ ENDQUOTE
     exit(2);
 }
 
-# set up default for cruftDirectory using the one from the input file, 
+# set up default for cruftDirectory using the one from the input file,
 # unless it has been specified using -c="/some/directory"
 $cruftDirectory=dirname $ARGV[0] unless(defined($cruftDirectory));
 
@@ -267,13 +267,17 @@ my @absPaths;
 # scalar to read user settings
 my $userSettings;
 
-# get information about user settings- first check if .latexindentconfig.yaml exists
-my $indentconfig = File::HomeDir->my_home . "/.latexindentconfig.yaml";
+# get information about user settings- first check if indentconfig.yaml exists
+my $indentconfig = File::HomeDir->my_home . "/indentconfig.yaml";
+
+# if indentconfig.yaml does not exist, then look for .indentconfig.yaml
+if ( ! -e $indentconfig){$indentconfig = File::HomeDir->my_home . "/.indentconfig.yaml";}
+
 if ( -e $indentconfig and !$onlyDefault )
 {
-      print $logfile "Reading path information from ",File::HomeDir->my_home,"/.latexindentconfig.yaml\n";
+      print $logfile "Reading path information from ",File::HomeDir->my_home,"/indentconfig.yaml\n";
 
-      # read the absolute paths from .latexindentconfig.yaml
+      # read the absolute paths from indentconfig.yaml
       $userSettings = YAML::Tiny->read( "$indentconfig" );
 
       # integrity check
@@ -298,15 +302,15 @@ else
 {
       if($onlyDefault)
       {
-        print $logfile "Only default settings requested, not reading USER settings from .latexindentconfig.yaml \n";
+        print $logfile "Only default settings requested, not reading USER settings from indentconfig.yaml \n";
         print $logfile "Ignoring localSettings.yaml\n" if($readLocalSettings);
         $readLocalSettings = 0;
       }
       else
       {
-        # give the user instructions on where to put .latexindentconfig.yaml
+        # give the user instructions on where to put indentconfig.yaml
         print $logfile "Home directory is ",File::HomeDir->my_home,"\n";
-        print $logfile "To specify user settings you would put .latexindentconfig.yaml here: \n\t",File::HomeDir->my_home,"/.latexindentconfig.yaml\n\n";
+        print $logfile "To specify user settings you would put indentconfig.yaml here: \n\t",File::HomeDir->my_home,"/indentconfig.yaml\n\n";
       }
 }
 
@@ -399,7 +403,7 @@ foreach my $settings (@absPaths)
   else
   {
       # otherwise keep going, but put a warning in the log file
-      print $logfile "\nWARNING\n\t",File::HomeDir->my_home,"/.latexindentconfig.yaml\n";
+      print $logfile "\nWARNING\n\t",File::HomeDir->my_home,"/indentconfig.yaml\n";
       if (-z $settings)
       {
           print $logfile "\tspecifies $settings \n\tbut this file is EMPTY- not reading from it\n\n"
@@ -1575,7 +1579,7 @@ sub at_beg_of_env_or_eq{
     #  ()       empty just so that $1 and $2 are defined
     #  (\\\[)   \[  there are lots of \ because both \ and [ need escaping
     #  \\begin{\\?(.*?)}  \begin{something} where something could start
-    #                     with a backslash, e.g \my@env@ which can happen 
+    #                     with a backslash, e.g \my@env@ which can happen
     #                     in a style or class file, for example
 
     if( (   ( $_ =~ m/^\s*(\$)?\\begin{\\?(.*?)}/ and $_ !~ m/\\end{$2}/)
@@ -1662,9 +1666,9 @@ sub at_end_of_env_or_eq{
             &decrease_indent($indentNames[-1]);
        }
 
-       # some commands contain \end{environmentname}, which 
-       # can cause a problem if \begin{environmentname} was not 
-       # started previously; if @environmentStack is empty, 
+       # some commands contain \end{environmentname}, which
+       # can cause a problem if \begin{environmentname} was not
+       # started previously; if @environmentStack is empty,
        # then we don't need to check for \end{environmentname}
        if(@environmentStack)
        {

--- a/latexindent.pl
+++ b/latexindent.pl
@@ -267,13 +267,13 @@ my @absPaths;
 # scalar to read user settings
 my $userSettings;
 
-# get information about user settings- first check if indentconfig.yaml exists
-my $indentconfig = File::HomeDir->my_home . "/indentconfig.yaml";
+# get information about user settings- first check if .latexindentconfig.yaml exists
+my $indentconfig = File::HomeDir->my_home . "/.latexindentconfig.yaml";
 if ( -e $indentconfig and !$onlyDefault )
 {
-      print $logfile "Reading path information from ",File::HomeDir->my_home,"/indentconfig.yaml\n";
+      print $logfile "Reading path information from ",File::HomeDir->my_home,"/.latexindentconfig.yaml\n";
 
-      # read the absolute paths from indentconfig.yaml
+      # read the absolute paths from .latexindentconfig.yaml
       $userSettings = YAML::Tiny->read( "$indentconfig" );
 
       # integrity check
@@ -298,15 +298,15 @@ else
 {
       if($onlyDefault)
       {
-        print $logfile "Only default settings requested, not reading USER settings from indentconfig.yaml \n";
+        print $logfile "Only default settings requested, not reading USER settings from .latexindentconfig.yaml \n";
         print $logfile "Ignoring localSettings.yaml\n" if($readLocalSettings);
         $readLocalSettings = 0;
       }
       else
       {
-        # give the user instructions on where to put indentconfig.yaml
+        # give the user instructions on where to put .latexindentconfig.yaml
         print $logfile "Home directory is ",File::HomeDir->my_home,"\n";
-        print $logfile "To specify user settings you would put indentconfig.yaml here: \n\t",File::HomeDir->my_home,"/indentconfig.yaml\n\n";
+        print $logfile "To specify user settings you would put .latexindentconfig.yaml here: \n\t",File::HomeDir->my_home,"/.latexindentconfig.yaml\n\n";
       }
 }
 
@@ -399,7 +399,7 @@ foreach my $settings (@absPaths)
   else
   {
       # otherwise keep going, but put a warning in the log file
-      print $logfile "\nWARNING\n\t",File::HomeDir->my_home,"/indentconfig.yaml\n";
+      print $logfile "\nWARNING\n\t",File::HomeDir->my_home,"/.latexindentconfig.yaml\n";
       if (-z $settings)
       {
           print $logfile "\tspecifies $settings \n\tbut this file is EMPTY- not reading from it\n\n"

--- a/latexindent.pl
+++ b/latexindent.pl
@@ -270,12 +270,31 @@ my $userSettings;
 # get information about user settings- first check if indentconfig.yaml exists
 my $indentconfig = File::HomeDir->my_home . "/indentconfig.yaml";
 
-# if indentconfig.yaml does not exist, then look for .indentconfig.yaml
-if ( ! -e $indentconfig){$indentconfig = File::HomeDir->my_home . "/.indentconfig.yaml";}
+if ( -e $indentconfig)
+{
+      print $logfile "Using settings file $indentconfig\n";
+      if ( -e File::HomeDir->my_home . "/.indentconfig.yaml"){
+        print $logfile File::HomeDir->my_home,"/.indentconfig.yaml has been found, but $indentconfig takes priority\n";
+      }
+      else
+      {
+        print $logfile "Alternatively, ",File::HomeDir->my_home,"/.indentconfig.yaml can be used\n";
+      }
+}
+else
+{
+      $indentconfig = File::HomeDir->my_home . "/.indentconfig.yaml";
+      if ( -e $indentconfig)
+      {
+        print $logfile "Using settings file $indentconfig\n";
+        print $logfile "Alternatively, ",File::HomeDir->my_home,"/indentconfig.yaml can be used\n";
+      }
+}
 
 if ( -e $indentconfig and !$onlyDefault )
 {
-      print $logfile "Reading path information from ",File::HomeDir->my_home,"/indentconfig.yaml\n";
+      print $logfile "Reading path information from $indentconfig\n";
+      print $logfile "Only default settings requested, not reading USER settings from $indentconfig\n";
 
       # read the absolute paths from indentconfig.yaml
       $userSettings = YAML::Tiny->read( "$indentconfig" );
@@ -302,15 +321,16 @@ else
 {
       if($onlyDefault)
       {
-        print $logfile "Only default settings requested, not reading USER settings from indentconfig.yaml \n";
+        print $logfile "Only default settings requested, not reading USER settings from $indentconfig\n";
         print $logfile "Ignoring localSettings.yaml\n" if($readLocalSettings);
         $readLocalSettings = 0;
       }
       else
       {
-        # give the user instructions on where to put indentconfig.yaml
+        # give the user instructions on where to put indentconfig.yaml or .indentconfig.yaml
         print $logfile "Home directory is ",File::HomeDir->my_home,"\n";
         print $logfile "To specify user settings you would put indentconfig.yaml here: \n\t",File::HomeDir->my_home,"/indentconfig.yaml\n\n";
+        print $logfile "Alternatively, you can use the hidden file .indentconfig.yaml as: \n\t",File::HomeDir->my_home,"/.indentconfig.yaml\n\n";
       }
 }
 


### PR DESCRIPTION
Config files are usually hidden, so this commit proposes a change in the name of indentconfig.yaml, prepending a dot (to make the file hidden) and the latex prefix, to avoid potential conflicts with other software.

