### PR TITLE
add in make install/uninstall support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8)
+project(latexindent)
+
+install(PROGRAMS latexindent.pl
+        DESTINATION bin)
+
+install(FILES defaultSettings.yaml
+        DESTINATION bin)
+
+# uninstall target
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+    IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,30 @@
+@echo off
+goto check_Permissions
+
+:check_Permissions
+   net session >nul 2>&1
+    if NOT %errorLevel% == 0 (
+        echo ######## ########  ########   #######  ########  
+	    echo ##       ##     ## ##     ## ##     ## ##     ## 
+	    echo ##       ##     ## ##     ## ##     ## ##     ## 
+	    echo ######   ########  ########  ##     ## ########  
+	    echo ##       ##   ##   ##   ##   ##     ## ##   ##   
+	    echo ##       ##    ##  ##    ##  ##     ## ##    ##  
+	    echo ######## ##     ## ##     ##  #######  ##     ## 
+	    echo.
+	    echo.
+	    echo ####### ERROR: ADMINISTRATOR PRIVILEGES REQUIRED #########
+	    echo This script must be run as administrator to work properly!  
+	    echo If you're seeing this after clicking on a start menu icon, then right click on the shortcut and select "Run As Administrator".
+	    echo.
+	    PAUSE
+	    EXIT /B 1
+    )
+
+SET CURRENTDIR=%~dp0
+
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /f /v Path /t REG_EXPAND_SZ /d "%Path%%CURRENTDIR%
+
+echo Install successfull!
+
+PAUSE         

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,0 +1,31 @@
+@echo off
+goto check_Permissions
+
+:check_Permissions
+   net session >nul 2>&1
+    if NOT %errorLevel% == 0 (
+        echo ######## ########  ########   #######  ########  
+	    echo ##       ##     ## ##     ## ##     ## ##     ## 
+	    echo ##       ##     ## ##     ## ##     ## ##     ## 
+	    echo ######   ########  ########  ##     ## ########  
+	    echo ##       ##   ##   ##   ##   ##     ## ##   ##   
+	    echo ##       ##    ##  ##    ##  ##     ## ##    ##  
+	    echo ######## ##     ## ##     ##  #######  ##     ## 
+	    echo.
+	    echo.
+	    echo ####### ERROR: ADMINISTRATOR PRIVILEGES REQUIRED #########
+	    echo This script must be run as administrator to work properly!  
+	    echo If you're seeing this after clicking on a start menu icon, then right click on the shortcut and select "Run As Administrator".
+	    echo.
+	    PAUSE
+	    EXIT /B 1
+    )
+
+SET CURRENTDIR=%~dp0
+
+setlocal enabledelayedexpansion
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /f /v Path /t REG_SZ /d "!Path:;%CURRENTDIR%=!"
+
+echo Uninstall successfull!
+
+PAUSE  


### PR DESCRIPTION
This is for support to install latexindent in system PATH. 

To install:
    mkdir build && cd build
    mkdir cmake ..
    sudo make install

To uninstall:
    sudo make uninstall

Text editor plugins such as https://packagecontrol.io/packages/BeautifyLatex needs latexindent.pl be in PATH to work. This approach is cleaner than copying the source file to system folder manually.