### PR TITLE
Feature/output and local switch enhancement

### DIFF
--- a/LatexIndent/FileExtension.pm
+++ b/LatexIndent/FileExtension.pm
@@ -22,6 +22,7 @@ use open ':std', ':encoding(UTF-8)';
 use File::Basename; # to get the filename and directory path
 use Exporter qw/import/;
 use LatexIndent::GetYamlSettings qw/%masterSettings/;
+use LatexIndent::Switches qw/%switches/;
 our @EXPORT_OK = qw/file_extension_check/;
 
 sub file_extension_check{
@@ -89,6 +90,24 @@ sub file_extension_check{
 
     # store the file extension
     ${$self}{fileExtension} = $ext;
+
+    # check to see if -o switch is active
+    if($switches{outputToFile}){
+
+        my $strippedFileExtension = ${$self}{fileExtension};
+        $strippedFileExtension =~ s/\.//; 
+
+        # grab the name, directory, and extension of the output file
+        my ($name, $dir, $ext) = fileparse($switches{outputToFile}, $strippedFileExtension);
+
+        # if there is no extension, then add the extension from the file to be operated upon
+        if(!$ext){
+            $self->logger("Output file check",'heading');
+            $self->logger("-o switch called with file name without extension: $switches{outputToFile}");
+            $switches{outputToFile} = $name.($name=~m/\.\z/ ? q() : ".").$strippedFileExtension;
+            $self->logger("Updated to $switches{outputToFile} as the file extension of the input file is $strippedFileExtension");
+        }
+    }
 
     # read the file into the Document body
     my @lines;

--- a/LatexIndent/FileExtension.pm
+++ b/LatexIndent/FileExtension.pm
@@ -38,7 +38,8 @@ sub file_extension_check{
     my @fileExtensions = sort { $fileExtensionPreference{$a} <=> $fileExtensionPreference{$b} } keys(%fileExtensionPreference);
     
     # get the base file name, allowing for different extensions (possibly no extension)
-    my ($dir, $name, $ext) = fileparse($fileName, @fileExtensions);
+    my ($name, $dir, $ext) = fileparse($fileName, @fileExtensions);
+    ${$self}{baseName} = $name;
 
     # check to make sure given file type is supported
     if( -e $fileName  and !$ext ){
@@ -93,6 +94,15 @@ sub file_extension_check{
 
     # check to see if -o switch is active
     if($switches{outputToFile}){
+        
+        $self->logger("Output file check",'heading');
+
+        # the -o file name might begin with a + symbol
+        if($switches{outputToFile} =~ m/^\+(.*)/){
+            $self->logger("-o switch called with + symbol at the beginning: $switches{outputToFile}");
+            $switches{outputToFile} = ${$self}{baseName}.$1;
+            $self->logger("output file is now: $switches{outputToFile}");
+        }
 
         my $strippedFileExtension = ${$self}{fileExtension};
         $strippedFileExtension =~ s/\.//; 
@@ -102,7 +112,6 @@ sub file_extension_check{
 
         # if there is no extension, then add the extension from the file to be operated upon
         if(!$ext){
-            $self->logger("Output file check",'heading');
             $self->logger("-o switch called with file name without extension: $switches{outputToFile}");
             $switches{outputToFile} = $name.($name=~m/\.\z/ ? q() : ".").$strippedFileExtension;
             $self->logger("Updated to $switches{outputToFile} as the file extension of the input file is $strippedFileExtension");

--- a/LatexIndent/FileExtension.pm
+++ b/LatexIndent/FileExtension.pm
@@ -98,7 +98,7 @@ sub file_extension_check{
         $self->logger("Output file check",'heading');
 
         # the -o file name might begin with a + symbol
-        if($switches{outputToFile} =~ m/^\+(.*)/){
+        if($switches{outputToFile} =~ m/^\+(.*)/ and $1 ne "+"){
             $self->logger("-o switch called with + symbol at the beginning: $switches{outputToFile}");
             $switches{outputToFile} = ${$self}{baseName}.$1;
             $self->logger("output file is now: $switches{outputToFile}");
@@ -115,6 +115,25 @@ sub file_extension_check{
             $self->logger("-o switch called with file name without extension: $switches{outputToFile}");
             $switches{outputToFile} = $name.($name=~m/\.\z/ ? q() : ".").$strippedFileExtension;
             $self->logger("Updated to $switches{outputToFile} as the file extension of the input file is $strippedFileExtension");
+        }
+
+        # the -o file name might end with ++ in which case we wish to search for existence, 
+        # and then increment accordingly
+        $name =~ s/\.$//;
+        if($name =~ m/\+\+$/){
+            $self->logger("-o switch called with file name ending with ++: $switches{outputToFile}");
+            $name =~ s/\+\+$//;
+            $name = ${$self}{baseName} if ($name eq "");
+            my $outputFileCounter = 0;
+            my $fileName = $name.$outputFileCounter.".".$strippedFileExtension; 
+            $self->logger("will search for exisitence and increment counter, starting with $fileName");
+            while( -e $fileName ){
+                $self->logger("$fileName exists, incrementing counter");
+                $outputFileCounter++;
+                $fileName = $name.$outputFileCounter.".".$strippedFileExtension; 
+            }
+            $self->logger("$fileName does not exist, and will be the output file");
+            $switches{outputToFile} = $fileName;
         }
     }
 

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -35,7 +35,6 @@ our %previouslyFoundSettings;
 sub readSettings{
   my $self = shift;
   
-  $defaultSettings = YAML::Tiny->new;
   $defaultSettings = YAML::Tiny->read( "$FindBin::RealBin/defaultSettings.yaml" );
   $self->logger("YAML settings read",'heading');
   $self->logger("Reading defaultSettings.yaml from $FindBin::RealBin/defaultSettings.yaml");
@@ -141,6 +140,13 @@ sub readSettings{
 
   # add local settings to the paths, if appropriate
   foreach (@localSettings) {
+    # check for an extension (.yaml)
+    my ($dir, $name, $ext) = fileparse($_, "yaml");
+
+    # if no extension is found, append the current localSetting with .yaml
+    $_ = $_.($_=~m/\.\z/ ? q() : ".")."yaml" if(!$ext);
+
+    # check for existence and non-emptiness
     if ( (-e "$directoryName/$_") and !(-z "$directoryName/$_")) {
         $self->logger("Adding $directoryName/$_ to YAML read paths");
         push(@absPaths,"$directoryName/$_");

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -89,22 +89,53 @@ latexindent.pl --outputfile output.tex myfile.tex
 latexindent.pl myfile.tex > output.tex
 \end{commandshell}
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
-You can call the \texttt{-o} switch with the name of the output file \emph{without} an extension; in 
-this case, \texttt{latexindent.pl} will use the extension from the original file. For example, 
-the following two calls to \texttt{latexindent.pl} are equivalent:
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
+	You can call the \texttt{-o} switch with the name of the output file \emph{without} an extension; in
+	this case, \texttt{latexindent.pl} will use the extension from the original file. For example,
+	the following two calls to \texttt{latexindent.pl} are equivalent:
 	\begin{commandshell}
 latexindent.pl myfile.tex -o=output
 latexindent.pl myfile.tex -o=output.tex
 \end{commandshell}
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
-You can call the \texttt{-o} switch using a \texttt{+} symbol at the beginning, if you 
-wish to concacenate the name of the input file and the text given to the \texttt{-o} switch.
-For example, the following two calls to \texttt{latexindent.pl} are equivalent:
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
+	You can call the \texttt{-o} switch using a \texttt{+} symbol at the beginning; this will 
+    concacenate the name of the input file and the text given to the \texttt{-o} switch.
+	For example, the following two calls to \texttt{latexindent.pl} are equivalent:
 	\begin{commandshell}
 latexindent.pl myfile.tex -o=+new
 latexindent.pl myfile.tex -o=myfilenew.tex
+\end{commandshell}
+
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
+	You can call the \texttt{-o} switch using a \texttt{++} symbol at the end of the name 
+    of your output file; this tells \texttt{latexindent.pl} to search successively for 
+    the name of your output file concancaenated with $0, 1, \ldots$ while the name of the 
+    output file exists.  For example, 
+	\begin{commandshell}
+latexindent.pl myfile.tex -o=output++
+\end{commandshell}
+tells \texttt{latexindent.pl} to output to \texttt{output0.tex}, but if it exists then 
+output to \texttt{output1.tex}, and so on.
+
+Calling \texttt{latexindent.pl} with simply
+	\begin{commandshell}
+latexindent.pl myfile.tex -o=++
+\end{commandshell}
+tells it to output to \texttt{myfile0.tex}, but if it exists then output to \texttt{myfile1.tex}
+and so on.
+
+The \texttt{+} and \texttt{++} feature of the \texttt{-o} switch can be combined; for example, calling
+	\begin{commandshell}
+latexindent.pl myfile.tex -o=+out++
+\end{commandshell}
+tells \texttt{latexindent.pl} to output to \texttt{myfileout0.tex}, but if it exists, then 
+try \texttt{myfileout1.tex}, and so on.
+
+There is no need to specify a file extension when using the \texttt{++} feature, but if you wish to, 
+then you should include it \emph{after} the \texttt{++} symbols, for example
+	\begin{commandshell}
+latexindent.pl myfile.tex -o=+out++.tex
 \end{commandshell}
 
 	See \vref{app:differences} for details of how the interface has changed

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -146,28 +146,33 @@ latexindent.pl myfile.tex -l=first.yaml,second.yaml,third.yaml
 	absolute paths -- for absolute paths, see \vref{sec:indentconfig}.
 	Explicit demonstrations of how to use the \texttt{-l} switch are given throughout this documentation.
 
-    As of Version 3.2.1, you can call the \texttt{-l} switch with a `+' symbol either before or after
-    another YAML file; for example:
-    \begin{commandshell}
+	You can call the \texttt{-l} switch with a `+' symbol either before or after
+	another YAML file; for example:
+	\begin{commandshell}
 latexindent.pl -l=+myyaml.yaml  myfile.tex
 latexindent.pl -l "+ myyaml.yaml" myfile.tex
 latexindent.pl -l=myyaml.yaml+  myfile.tex
     \end{commandshell}
-   which translate, respectively, to
-    \begin{commandshell}
+	which translate, respectively, to
+	\begin{commandshell}
 latexindent.pl -l=localSettings.yaml,myyaml.yaml myfile.tex
 latexindent.pl -l=localSettings.yaml,myyaml.yaml myfile.tex
 latexindent.pl -l=myyaml.yaml,localSettings.yaml myfile.tex
     \end{commandshell}
-    Note that the following is \emph{not} allowed:
-    \begin{commandshell}
+	Note that the following is \emph{not} allowed:
+	\begin{commandshell}
 latexindent.pl -l+myyaml.yaml myfile.tex
     \end{commandshell}
-   and
-    \begin{commandshell}
+	and
+	\begin{commandshell}
 latexindent.pl -l + myyaml.yaml myfile.tex
     \end{commandshell}
-    will \emph{only} load \texttt{localSettings.yaml}, and \texttt{myyaml.yaml} will be ignored.
+	will \emph{only} load \texttt{localSettings.yaml}, and \texttt{myyaml.yaml} will be ignored.
+
+	You may also choose to omit the \texttt{yaml} extension, such as
+	\begin{commandshell}
+latexindent.pl -l=localSettings,myyaml myfile.tex
+    \end{commandshell}
 \flagbox{-d, --onlydefault}
 	\begin{commandshell}
 latexindent.pl -d myfile.tex

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -84,10 +84,22 @@ latexindent.pl --outputfile output.tex myfile.tex
 	be ignored and \texttt{-o} will take priority (this seems safer than the
 	other way round).
 
-	Note that using \texttt{-o} is equivalent to using
+	Note that using \texttt{-o} as above is equivalent to using
 	\begin{commandshell}
 latexindent.pl myfile.tex > output.tex
 \end{commandshell}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
+You can call the \texttt{-o} switch with the name of a file \emph{without} an extension; in 
+this case, \texttt{latexindent.pl} will use the extension from the original file. For example, 
+	\begin{commandshell}
+latexindent.pl myfile.tex -o=output
+\end{commandshell}
+will be interpreted in the same way as
+	\begin{commandshell}
+latexindent.pl myfile.tex -o=output.tex
+\end{commandshell}
+
 	See \vref{app:differences} for details of how the interface has changed
 	from Version 2.2 to Version 3.0 for this flag.
 \flagbox{-s, --silent}

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -146,6 +146,28 @@ latexindent.pl myfile.tex -l=first.yaml,second.yaml,third.yaml
 	absolute paths -- for absolute paths, see \vref{sec:indentconfig}.
 	Explicit demonstrations of how to use the \texttt{-l} switch are given throughout this documentation.
 
+    As of Version 3.2.1, you can call the \texttt{-l} switch with a `+' symbol either before or after
+    another YAML file; for example:
+    \begin{commandshell}
+latexindent.pl -l=+myyaml.yaml  myfile.tex
+latexindent.pl -l "+ myyaml.yaml" myfile.tex
+latexindent.pl -l=myyaml.yaml+  myfile.tex
+    \end{commandshell}
+   which translate, respectively, to
+    \begin{commandshell}
+latexindent.pl -l=localSettings.yaml,myyaml.yaml myfile.tex
+latexindent.pl -l=localSettings.yaml,myyaml.yaml myfile.tex
+latexindent.pl -l=myyaml.yaml,localSettings.yaml myfile.tex
+    \end{commandshell}
+    Note that the following is \emph{not} allowed:
+    \begin{commandshell}
+latexindent.pl -l+myyaml.yaml myfile.tex
+    \end{commandshell}
+   and
+    \begin{commandshell}
+latexindent.pl -l + myyaml.yaml myfile.tex
+    \end{commandshell}
+    will \emph{only} load \texttt{localSettings.yaml}, and \texttt{myyaml.yaml} will be ignored.
 \flagbox{-d, --onlydefault}
 	\begin{commandshell}
 latexindent.pl -d myfile.tex

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -90,14 +90,21 @@ latexindent.pl myfile.tex > output.tex
 \end{commandshell}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
-You can call the \texttt{-o} switch with the name of a file \emph{without} an extension; in 
+You can call the \texttt{-o} switch with the name of the output file \emph{without} an extension; in 
 this case, \texttt{latexindent.pl} will use the extension from the original file. For example, 
+the following two calls to \texttt{latexindent.pl} are equivalent:
 	\begin{commandshell}
 latexindent.pl myfile.tex -o=output
-\end{commandshell}
-will be interpreted in the same way as
-	\begin{commandshell}
 latexindent.pl myfile.tex -o=output.tex
+\end{commandshell}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\announce{NEW}
+You can call the \texttt{-o} switch using a \texttt{+} symbol at the beginning, if you 
+wish to concacenate the name of the input file and the text given to the \texttt{-o} switch.
+For example, the following two calls to \texttt{latexindent.pl} are equivalent:
+	\begin{commandshell}
+latexindent.pl myfile.tex -o=+new
+latexindent.pl myfile.tex -o=myfilenew.tex
 \end{commandshell}
 
 	See \vref{app:differences} for details of how the interface has changed

--- a/test-cases/fileextensions/cmh.bib
+++ b/test-cases/fileextensions/cmh.bib
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/cmh.tex
+++ b/test-cases/fileextensions/cmh.tex
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/cmhone.tex
+++ b/test-cases/fileextensions/cmhone.tex
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/cmhtwo.tex
+++ b/test-cases/fileextensions/cmhtwo.tex
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/file-extension-test-cases.sh
+++ b/test-cases/fileextensions/file-extension-test-cases.sh
@@ -28,5 +28,13 @@ latexindent.pl -s cmh -tt -o two -g=two.log
 latexindent.pl -s cmh -tt -o three. -g=three.log
 latexindent.pl -s cmh.bib -tt -o one -g=four.log
 latexindent.pl -s cmh.bib -tt -o two. -g=five.log
+# the output file can be called with a + sign, e.g
+#       latexindent.pl cmh.tex -o=+one.tex
+#       latexindent.pl cmh.tex -o=+one
+# both of which are equivalent to
+#       latexindent.pl cmh.tex -o=cmhone.tex
+latexindent.pl -s cmh.tex -tt -o +one -g=six.log
+latexindent.pl -s cmh.tex -tt -o +two.tex -g=seven.log
+
 git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/fileextensions/file-extension-test-cases.sh
+++ b/test-cases/fileextensions/file-extension-test-cases.sh
@@ -20,5 +20,7 @@ latexindent.pl  tabular-karl -tt -l="   +../alignment/multiColumnGrouping.yaml" 
 latexindent.pl  tabular-karl -tt -l="   +   ../alignment/multiColumnGrouping.yaml" -s -o=tabular-karl3.tex 
 latexindent.pl  tabular-karl -tt -l=../alignment/multiColumnGrouping.yaml+ -s -o=tabular-karl4.tex 
 latexindent.pl  tabular-karl -tt -l="../alignment/multiColumnGrouping.yaml    +" -s -o=tabular-karl5.tex -g=one.log
+# no yaml extension
+latexindent.pl  tabular-karl -tt -l=+../alignment/multiColumnGrouping -s -o=tabular-karl6.tex 
 git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/fileextensions/file-extension-test-cases.sh
+++ b/test-cases/fileextensions/file-extension-test-cases.sh
@@ -35,6 +35,17 @@ latexindent.pl -s cmh.bib -tt -o two. -g=five.log
 #       latexindent.pl cmh.tex -o=cmhone.tex
 latexindent.pl -s cmh.tex -tt -o +one -g=six.log
 latexindent.pl -s cmh.tex -tt -o +two.tex -g=seven.log
-
+# test the ++ routine:
+#       latexindent.pl myfile.tex -o=++
+# says that latexindent should output to myfile0.tex; if myfile0.tex exists, it should use myfile1.tex, and so on.
+#       latexindent.pl myfile.tex -o=output++
+# says that latexindent should output to output0.tex; if output0.tex exists, it should use output1.tex, and so on.
+#       latexindent.pl myfile.tex -o=+output++
+# says that latexindent should myfileoutput to myfileoutput0.tex; if myfileoutput0.tex exists, it should use myfileoutput1.tex, and so on.
+latexindent.pl cmh.tex -o=++ -s
+latexindent.pl cmh.tex -o=output++ -s
+latexindent.pl cmh.tex -o +output++ -s
+latexindent.pl cmh.tex -o +myfile++.tex -s
+latexindent.pl cmh.tex -o myfile++.tex -s
 git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/fileextensions/file-extension-test-cases.sh
+++ b/test-cases/fileextensions/file-extension-test-cases.sh
@@ -22,5 +22,11 @@ latexindent.pl  tabular-karl -tt -l=../alignment/multiColumnGrouping.yaml+ -s -o
 latexindent.pl  tabular-karl -tt -l="../alignment/multiColumnGrouping.yaml    +" -s -o=tabular-karl5.tex -g=one.log
 # no yaml extension
 latexindent.pl  tabular-karl -tt -l=+../alignment/multiColumnGrouping -s -o=tabular-karl6.tex 
+# no extension for output file
+latexindent.pl -s cmh.tex -tt -o one -g=one.log
+latexindent.pl -s cmh -tt -o two -g=two.log
+latexindent.pl -s cmh -tt -o three. -g=three.log
+latexindent.pl -s cmh.bib -tt -o one -g=four.log
+latexindent.pl -s cmh.bib -tt -o two. -g=five.log
 git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/fileextensions/file-extension-test-cases.sh
+++ b/test-cases/fileextensions/file-extension-test-cases.sh
@@ -14,4 +14,11 @@ latexindent.pl -w -s  myfile -g=myfile.log
 latexindent.pl -w -s  myfile -l=style-file-first.yaml -g=myfile-sty.log
 # won't work, as it will look for another.tex, another.cls, another.bib, another.sty
 latexindent.pl -w -s  another -g=one.log
+# the -l switch can accept a + symbol:
+latexindent.pl  tabular-karl -tt -l=+../alignment/multiColumnGrouping.yaml -s -o=tabular-karl1.tex 
+latexindent.pl  tabular-karl -tt -l="   +../alignment/multiColumnGrouping.yaml" -s -o=tabular-karl2.tex 
+latexindent.pl  tabular-karl -tt -l="   +   ../alignment/multiColumnGrouping.yaml" -s -o=tabular-karl3.tex 
+latexindent.pl  tabular-karl -tt -l=../alignment/multiColumnGrouping.yaml+ -s -o=tabular-karl4.tex 
+latexindent.pl  tabular-karl -tt -l="../alignment/multiColumnGrouping.yaml    +" -s -o=tabular-karl5.tex -g=one.log
 git status
+[[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/fileextensions/localSettings.yaml
+++ b/test-cases/fileextensions/localSettings.yaml
@@ -1,0 +1,4 @@
+lookForAlignDelims:
+   tabular: 
+      multiColumnGrouping: 0
+      alignRowsWithoutMaxDelims: 1

--- a/test-cases/fileextensions/one.bib
+++ b/test-cases/fileextensions/one.bib
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/one.tex
+++ b/test-cases/fileextensions/one.tex
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/tabular-karl.tex
+++ b/test-cases/fileextensions/tabular-karl.tex
@@ -1,0 +1,17 @@
+\begin{table}[h]
+  \caption{Muuntajan nimellisarvot ja ylajannitepuolelta mitatut arvot}
+  \centering
+  \begin{tabular}{r@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}l}
+    \toprule
+    \multicolumn{3}{l}{Nimellisarvot}&\multicolumn{3}{l}{Tyhjakayntikoe}&\multicolumn{3}{l}{Oikosulkukoe}\\ % & \multicolumn{40}{1}{something}
+    \midrule
+    $S_N$&$=$&$\SI{1000}{\kV\A}$&$U_0$&$=$&$U_{N1}$&$U_k$&$=$&$\SI{360}{\V}$\\
+    $U_{N1}$&$=$&$\SI{6000}{V}$&$I_0$&$=$&$\SI{1.67}{\ampere}$&$I_k$&$=$&$I_{N1}$\\
+    $U_{N2}$&$=$&$\SI{400}{\volt}$&$P_0$&$=$&$\SI{1550}{\watt}$&$P_k$&$=$&$\SI{8200}{\W}$\\
+    $f_N$&$=$&$\SI{50}{\hertz}$&&\\
+    \bottomrule
+    \multicolumn{6}{l}{Nimellisarvot}&\multicolumn{3}{l}{Oikosulkukoe}\\ % & \multicolumn{40}{1}{something}
+    \multicolumn{3}{l}{Nimellisarvot}&\multicolumn{3}{l}{Tyhjakayntikoe}&\multicolumn{3}{l}{Oikosulkukoe}\\ % & \multicolumn{40}{1}{something}
+    \multicolumn{6}{l}{Nimellisarvot}&more&text&here\\ % & \multicolumn{40}{1}{something}
+  \end{tabular}
+\end{table}

--- a/test-cases/fileextensions/tabular-karl1.tex
+++ b/test-cases/fileextensions/tabular-karl1.tex
@@ -1,0 +1,17 @@
+\begin{table}[h]
+	\caption{Muuntajan nimellisarvot ja ylajannitepuolelta mitatut arvot}
+	\centering
+	\begin{tabular}{r@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}l}
+		\toprule
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\midrule
+		$S_N$    & $=$ & $\SI{1000}{\kV\A}$ & $U_0$ & $=$ & $U_{N1}$             & $U_k$ & $=$  & $\SI{360}{\V}$    \\
+		$U_{N1}$ & $=$ & $\SI{6000}{V}$     & $I_0$ & $=$ & $\SI{1.67}{\ampere}$ & $I_k$ & $=$  & $I_{N1}$          \\
+		$U_{N2}$ & $=$ & $\SI{400}{\volt}$  & $P_0$ & $=$ & $\SI{1550}{\watt}$   & $P_k$ & $=$  & $\SI{8200}{\W}$   \\
+		$f_N$    & $=$ & $\SI{50}{\hertz}$  &       &                                                               \\
+		\bottomrule
+		\multicolumn{6}{l}{Nimellisarvot}                                        & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{6}{l}{Nimellisarvot}                                        & more  & text & here              \\ % & \multicolumn{40}{1}{something}
+	\end{tabular}
+\end{table}

--- a/test-cases/fileextensions/tabular-karl2.tex
+++ b/test-cases/fileextensions/tabular-karl2.tex
@@ -1,0 +1,17 @@
+\begin{table}[h]
+	\caption{Muuntajan nimellisarvot ja ylajannitepuolelta mitatut arvot}
+	\centering
+	\begin{tabular}{r@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}l}
+		\toprule
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\midrule
+		$S_N$    & $=$ & $\SI{1000}{\kV\A}$ & $U_0$ & $=$ & $U_{N1}$             & $U_k$ & $=$  & $\SI{360}{\V}$    \\
+		$U_{N1}$ & $=$ & $\SI{6000}{V}$     & $I_0$ & $=$ & $\SI{1.67}{\ampere}$ & $I_k$ & $=$  & $I_{N1}$          \\
+		$U_{N2}$ & $=$ & $\SI{400}{\volt}$  & $P_0$ & $=$ & $\SI{1550}{\watt}$   & $P_k$ & $=$  & $\SI{8200}{\W}$   \\
+		$f_N$    & $=$ & $\SI{50}{\hertz}$  &       &                                                               \\
+		\bottomrule
+		\multicolumn{6}{l}{Nimellisarvot}                                        & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{6}{l}{Nimellisarvot}                                        & more  & text & here              \\ % & \multicolumn{40}{1}{something}
+	\end{tabular}
+\end{table}

--- a/test-cases/fileextensions/tabular-karl3.tex
+++ b/test-cases/fileextensions/tabular-karl3.tex
@@ -1,0 +1,17 @@
+\begin{table}[h]
+	\caption{Muuntajan nimellisarvot ja ylajannitepuolelta mitatut arvot}
+	\centering
+	\begin{tabular}{r@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}l}
+		\toprule
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\midrule
+		$S_N$    & $=$ & $\SI{1000}{\kV\A}$ & $U_0$ & $=$ & $U_{N1}$             & $U_k$ & $=$  & $\SI{360}{\V}$    \\
+		$U_{N1}$ & $=$ & $\SI{6000}{V}$     & $I_0$ & $=$ & $\SI{1.67}{\ampere}$ & $I_k$ & $=$  & $I_{N1}$          \\
+		$U_{N2}$ & $=$ & $\SI{400}{\volt}$  & $P_0$ & $=$ & $\SI{1550}{\watt}$   & $P_k$ & $=$  & $\SI{8200}{\W}$   \\
+		$f_N$    & $=$ & $\SI{50}{\hertz}$  &       &                                                               \\
+		\bottomrule
+		\multicolumn{6}{l}{Nimellisarvot}                                        & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{6}{l}{Nimellisarvot}                                        & more  & text & here              \\ % & \multicolumn{40}{1}{something}
+	\end{tabular}
+\end{table}

--- a/test-cases/fileextensions/tabular-karl4.tex
+++ b/test-cases/fileextensions/tabular-karl4.tex
@@ -1,0 +1,17 @@
+\begin{table}[h]
+	\caption{Muuntajan nimellisarvot ja ylajannitepuolelta mitatut arvot}
+	\centering
+	\begin{tabular}{r@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}l}
+		\toprule
+		\multicolumn{3}{l}{Nimellisarvot} & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe}                                                                      \\ % & \multicolumn{40}{1}{something}
+		\midrule
+		$S_N$                             & $=$                                & $\SI{1000}{\kV\A}$               & $U_0$ & $=$ & $U_{N1}$             & $U_k$ & $=$ & $\SI{360}{\V}$  \\
+		$U_{N1}$                          & $=$                                & $\SI{6000}{V}$                   & $I_0$ & $=$ & $\SI{1.67}{\ampere}$ & $I_k$ & $=$ & $I_{N1}$        \\
+		$U_{N2}$                          & $=$                                & $\SI{400}{\volt}$                & $P_0$ & $=$ & $\SI{1550}{\watt}$   & $P_k$ & $=$ & $\SI{8200}{\W}$ \\
+		$f_N$                             & $=$                                & $\SI{50}{\hertz}$                &       &                                                            \\
+		\bottomrule
+		\multicolumn{6}{l}{Nimellisarvot} & \multicolumn{3}{l}{Oikosulkukoe}                                                                                                           \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{3}{l}{Nimellisarvot} & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe}                                                                      \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{6}{l}{Nimellisarvot} & more                               & text                             & here                                                               \\ % & \multicolumn{40}{1}{something}
+	\end{tabular}
+\end{table}

--- a/test-cases/fileextensions/tabular-karl5.tex
+++ b/test-cases/fileextensions/tabular-karl5.tex
@@ -1,0 +1,17 @@
+\begin{table}[h]
+	\caption{Muuntajan nimellisarvot ja ylajannitepuolelta mitatut arvot}
+	\centering
+	\begin{tabular}{r@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}l}
+		\toprule
+		\multicolumn{3}{l}{Nimellisarvot} & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe}                                                                      \\ % & \multicolumn{40}{1}{something}
+		\midrule
+		$S_N$                             & $=$                                & $\SI{1000}{\kV\A}$               & $U_0$ & $=$ & $U_{N1}$             & $U_k$ & $=$ & $\SI{360}{\V}$  \\
+		$U_{N1}$                          & $=$                                & $\SI{6000}{V}$                   & $I_0$ & $=$ & $\SI{1.67}{\ampere}$ & $I_k$ & $=$ & $I_{N1}$        \\
+		$U_{N2}$                          & $=$                                & $\SI{400}{\volt}$                & $P_0$ & $=$ & $\SI{1550}{\watt}$   & $P_k$ & $=$ & $\SI{8200}{\W}$ \\
+		$f_N$                             & $=$                                & $\SI{50}{\hertz}$                &       &                                                            \\
+		\bottomrule
+		\multicolumn{6}{l}{Nimellisarvot} & \multicolumn{3}{l}{Oikosulkukoe}                                                                                                           \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{3}{l}{Nimellisarvot} & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe}                                                                      \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{6}{l}{Nimellisarvot} & more                               & text                             & here                                                               \\ % & \multicolumn{40}{1}{something}
+	\end{tabular}
+\end{table}

--- a/test-cases/fileextensions/tabular-karl6.tex
+++ b/test-cases/fileextensions/tabular-karl6.tex
@@ -1,0 +1,17 @@
+\begin{table}[h]
+	\caption{Muuntajan nimellisarvot ja ylajannitepuolelta mitatut arvot}
+	\centering
+	\begin{tabular}{r@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}lr@{\hspace{2pt}}c@{\hspace{2pt}}l}
+		\toprule
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\midrule
+		$S_N$    & $=$ & $\SI{1000}{\kV\A}$ & $U_0$ & $=$ & $U_{N1}$             & $U_k$ & $=$  & $\SI{360}{\V}$    \\
+		$U_{N1}$ & $=$ & $\SI{6000}{V}$     & $I_0$ & $=$ & $\SI{1.67}{\ampere}$ & $I_k$ & $=$  & $I_{N1}$          \\
+		$U_{N2}$ & $=$ & $\SI{400}{\volt}$  & $P_0$ & $=$ & $\SI{1550}{\watt}$   & $P_k$ & $=$  & $\SI{8200}{\W}$   \\
+		$f_N$    & $=$ & $\SI{50}{\hertz}$  &       &                                                               \\
+		\bottomrule
+		\multicolumn{6}{l}{Nimellisarvot}                                        & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{3}{l}{Nimellisarvot}   & \multicolumn{3}{l}{Tyhjakayntikoe} & \multicolumn{3}{l}{Oikosulkukoe} \\ % & \multicolumn{40}{1}{something}
+		\multicolumn{6}{l}{Nimellisarvot}                                        & more  & text & here              \\ % & \multicolumn{40}{1}{something}
+	\end{tabular}
+\end{table}

--- a/test-cases/fileextensions/three.tex
+++ b/test-cases/fileextensions/three.tex
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/two.bib
+++ b/test-cases/fileextensions/two.bib
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/fileextensions/two.tex
+++ b/test-cases/fileextensions/two.tex
@@ -1,0 +1,1 @@
+not much text

--- a/test-cases/items/spaces-and-tabs-tfs.tex
+++ b/test-cases/items/spaces-and-tabs-tfs.tex
@@ -1,10 +1,10 @@
 \begin{one}
-	one body text
-	one body text
-	one body text
-	\begin{two}
-		two body text
-		two body text
-		two body text
-	\end{two}
+     one body text
+     one body text
+     one body text
+     \begin{two}
+	     two body text
+	     two body text
+	     two body text
+     \end{two}
 \end{one}


### PR DESCRIPTION
This pull request represents the development of the features described in https://github.com/cmhughes/latexindent.pl/issues/42.

Specifically,
- `-l=myyaml.yaml+` loads `myyaml.yaml` followed by `localSettings.yaml`
- `-l=+myyaml.yaml` loads `localSettings.yaml` followed by `myyaml.yaml`
- `-o=+<text>`  outputs to `filename<text>.tex`
- `-o=++`  outputs to `filename1.tex`, `filename2.tex`, etc (checking for existence first)
- `-o=+<text>++`  outputs to `filename<text>1.tex`, `filename<text>2.tex`. etc (checking for existence first)
