### PR TITLE
V3.2.2: removeTrailingWhitespace can be specified as a scalar

### DIFF
--- a/LatexIndent/HorizontalWhiteSpace.pm
+++ b/LatexIndent/HorizontalWhiteSpace.pm
@@ -25,6 +25,23 @@ sub remove_trailing_whitespace{
     my $self = shift;
     my %input = @_;
 
+    # removeTrailingWhitespace can be either a hash or a scalar, but if
+    # it's a scalar, we need to fix it
+    if(ref($masterSettings{removeTrailingWhitespace}) ne 'HASH'){
+        $self->logger("removeTrailingWhitespace specified as scalar, will update it to be a hash",'heading') if $is_t_switch_active;
+        # grab the value
+        my $removeTWS = $masterSettings{removeTrailingWhitespace};
+
+        # delete the scalar
+        delete $masterSettings{removeTrailingWhitespace};
+
+        # redefine it as a hash
+        ${$masterSettings{removeTrailingWhitespace}}{beforeProcessing} = $removeTWS; 
+        ${$masterSettings{removeTrailingWhitespace}}{afterProcessing} = $removeTWS; 
+        $self->logger("removeTrailingWhitespace: beforeProcessing is now $removeTWS") if $is_t_switch_active;
+        $self->logger("removeTrailingWhitespace: afterProcessing is now $removeTWS") if $is_t_switch_active;
+    }
+
     # this method can be called before the indendation, and after, depending upon the input
     if($input{when} eq "before"){
         return unless(${$masterSettings{removeTrailingWhitespace}}{beforeProcessing});

--- a/LatexIndent/Version.pm
+++ b/LatexIndent/Version.pm
@@ -19,6 +19,6 @@ use warnings;
 use Exporter qw/import/;
 our @EXPORT_OK = qw/$versionNumber $versionDate/;
 
-our $versionNumber = '3.2.1';
-our $versionDate = '2017-06-25';
+our $versionNumber = '3.2.2';
+our $versionDate = '2017-06-28';
 1

--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -1,4 +1,4 @@
-# defaultSettings.yaml for latexindent.pl, version 3.2.1, 2017-06-25
+# defaultSettings.yaml for latexindent.pl, version 3.2.2, 2017-06-28
 #                      a script that aims to
 #                      beautify .tex, .sty, .cls files
 #

--- a/documentation/latexindent.tex
+++ b/documentation/latexindent.tex
@@ -541,38 +541,7 @@
 
 \begin{document}
 \renewcommand*{\thefootnote}{\arabic{footnote}}
-\title{%
-	\begin{tcolorbox}[
-			width=5.2cm,
-			boxrule=0pt,
-			colframe=white!40!black,
-			colback=white,
-			rightrule=2pt,
-			sharp corners,
-			enhanced,
-			overlay={\node[anchor=north east,outer sep=2pt] at ([xshift=3cm,yshift=4mm]frame.north east) {\includegraphics[width=3cm]{logo}}; }]
-		\centering\ttfamily\bfseries latexindent.pl\\[1cm] Version 3.2.1
-	\end{tcolorbox}
-}
-\author{Chris Hughes \thanks{and contributors! See \vref{sec:contributors}. For
-		all communication, please visit \cite{latexindent-home}.}}
-\maketitle
-\begin{adjustwidth}{1cm}{1cm}
-	\small
-	\texttt{latexindent.pl} is a \texttt{Perl} script that indents \texttt{.tex} (and other)
-	files according to an indentation scheme that the user can modify to suit their
-	taste. Environments, including those with alignment delimiters (such as \texttt{tabular}),
-	and commands, including those that can split braces and brackets across lines,
-	are \emph{usually} handled correctly by the script. Options for \texttt{verbatim}-like
-	environments and commands, together with indentation after headings (such as \lstinline!chapter!, \lstinline!section!, etc)
-	are also available. The script also has the ability to modifiy line breaks, and add
-	comment symbols. All user options are customisable via the switches in the YAML interface.
-\end{adjustwidth}
-\tableofcontents
-{\small
-	\lstlistoflistings
-}
-
+\input{title.tex}
 \input{sec-introduction}
 \input{sec-demonstration}
 \input{sec-how-to-use}

--- a/documentation/latexindent.tex
+++ b/documentation/latexindent.tex
@@ -621,22 +621,22 @@ v2.2 addresses a reg­exp issue, and adds a few enhancements; full details are h
 https://www.ctan.org/ctan-ann/id/mailman.198.1477655196.4574.ctan-ann@ctan.org
 
 Version 3.0
-latexindent.pl version 3.0: this represents a complete re-build of the script; full details are given here: 
+latexindent.pl version 3.0: this represents a complete re-build of the script; full details are given here:
 https://github.com/cmhughes/la­texin­dent.pl/pull/56
 
-V3.0.1 
-pro­vides sup­port for the align­ment at am­per­sands rou­tine for code that con­tains uni­code char­ac­ters; see 
+V3.0.1
+pro­vides sup­port for the align­ment at am­per­sands rou­tine for code that con­tains uni­code char­ac­ters; see
 https://github.com/cmhughes/la­texin­dent.pl/pull/61
 
 V3.0.2
-A mi­nor re­lease to fix a small bug re­lated to in­den­tPream­ble; de­tails given here: 
+A mi­nor re­lease to fix a small bug re­lated to in­den­tPream­ble; de­tails given here:
 https://github.com/cmhughes/la­texin­dent.pl/pull/62
 
-Ver­sion 3.1 of la­texin­dent.pl, 
-in­clud­ing op­tions for text wrap­ping and para­graph line break re­moval. Full de­tails here: 
+Ver­sion 3.1 of la­texin­dent.pl,
+in­clud­ing op­tions for text wrap­ping and para­graph line break re­moval. Full de­tails here:
 https://github.com/cmhughes/la­texin­dent.pl/pull/64
 
-Ver­sion 3.2 
-im­ple­ments a new fea­ture called 'mul­ti­Colum­nGroup­ing' which gives a new op­tion for the align­ment-at-am­per­sands rou­tine. 
-More de­tails are given at 
+Ver­sion 3.2
+im­ple­ments a new fea­ture called 'mul­ti­Colum­nGroup­ing' which gives a new op­tion for the align­ment-at-am­per­sands rou­tine.
+More de­tails are given at
 https://github.com/cmhughes/la­texin­dent.pl/pull/67

--- a/documentation/readme.txt
+++ b/documentation/readme.txt
@@ -1,5 +1,5 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    latexindent.pl, version 3.2.1, 2017-06-25
+    latexindent.pl, version 3.2.2, 2017-06-28
 
     PERL script to indent code within environments, and align delimited 
     environments in .tex files.

--- a/documentation/sec-default-user-local.tex
+++ b/documentation/sec-default-user-local.tex
@@ -140,19 +140,28 @@ copy myfile.bak4 to myfile.bak3
 
 \yamltitle{removeTrailingWhitespace}*{fields}\label{yaml:removeTrailingWhitespace}
 
-	\begin{wrapfigure}[12]{r}[0pt]{6cm}
+	\begin{wrapfigure}[10]{r}[0pt]{7cm}
 		\cmhlistingsfromfile[style=removeTrailingWhitespace]{../defaultSettings.yaml}[width=.8\linewidth,before=\centering,yaml-TCB]{removeTrailingWhitespace}{lst:removeTrailingWhitespace}
 
-		\vspace{.2cm}
-		\cmhlistingsfromfile[style=fileContentsEnvironments]{../defaultSettings.yaml}[width=.8\linewidth,before=\centering,yaml-TCB]{\texttt{fileContentsEnvironments}}{lst:fileContentsEnvironments}
+        \vspace{.1cm}
+		\begin{yaml}[numbers=none]{removeTrailingWhitespace (alt)}[width=.8\linewidth,before=\centering]{lst:removeTrailingWhitespace-alt}
+removeTrailingWhitespace: 1
+\end{yaml}
 	\end{wrapfigure}
 	Trailing white space can be removed both \emph{before} and \emph{after} processing
 	the document, as detailed in \cref{lst:removeTrailingWhitespace}; each of the fields
 	can take the values \texttt{0} or \texttt{1}. See \vref{lst:removeTWS-before,lst:env-mlb5-modAll,lst:env-mlb5-modAll-remove-WS}
 	for before and after results.  Thanks to \cite{vosskuhle} for providing this feature.
 
+    You can specify \texttt{removeTrailingWhitespace} simply as \texttt{0} or \texttt{1}, if you wish; in this case, 
+    \announce{NEW}
+    \texttt{latexindent.pl} will set both \texttt{beforeProcessing} and \texttt{afterProcessing} to the value you specify; 
+    see \cref{lst:removeTrailingWhitespace-alt}.
 \yamltitle{fileContentsEnvironments}*{field}
 
+	\begin{wrapfigure}[6]{r}[0pt]{6cm}
+		\cmhlistingsfromfile[style=fileContentsEnvironments]{../defaultSettings.yaml}[width=.8\linewidth,before=\centering,yaml-TCB]{\texttt{fileContentsEnvironments}}{lst:fileContentsEnvironments}
+	\end{wrapfigure}
 	Before \texttt{latexindent.pl} determines the difference between preamble (if any) and the main document,
 	it first searches for any of the environments specified in \texttt{fileContentsEnvironments}, see
 	\cref{lst:fileContentsEnvironments}.

--- a/documentation/sec-default-user-local.tex
+++ b/documentation/sec-default-user-local.tex
@@ -143,7 +143,7 @@ copy myfile.bak4 to myfile.bak3
 	\begin{wrapfigure}[10]{r}[0pt]{7cm}
 		\cmhlistingsfromfile[style=removeTrailingWhitespace]{../defaultSettings.yaml}[width=.8\linewidth,before=\centering,yaml-TCB]{removeTrailingWhitespace}{lst:removeTrailingWhitespace}
 
-        \vspace{.1cm}
+		\vspace{.1cm}
 		\begin{yaml}[numbers=none]{removeTrailingWhitespace (alt)}[width=.8\linewidth,before=\centering]{lst:removeTrailingWhitespace-alt}
 removeTrailingWhitespace: 1
 \end{yaml}
@@ -153,10 +153,10 @@ removeTrailingWhitespace: 1
 	can take the values \texttt{0} or \texttt{1}. See \vref{lst:removeTWS-before,lst:env-mlb5-modAll,lst:env-mlb5-modAll-remove-WS}
 	for before and after results.  Thanks to \cite{vosskuhle} for providing this feature.
 
-    You can specify \texttt{removeTrailingWhitespace} simply as \texttt{0} or \texttt{1}, if you wish; in this case, 
-    \announce{NEW}
-    \texttt{latexindent.pl} will set both \texttt{beforeProcessing} and \texttt{afterProcessing} to the value you specify; 
-    see \cref{lst:removeTrailingWhitespace-alt}.
+	You can specify \texttt{removeTrailingWhitespace} simply as \texttt{0} or \texttt{1}, if you wish; in this case,
+	\announce*{2017-06-28}
+	\texttt{latexindent.pl} will set both \texttt{beforeProcessing} and \texttt{afterProcessing} to the value you specify;
+	see \cref{lst:removeTrailingWhitespace-alt}.
 \yamltitle{fileContentsEnvironments}*{field}
 
 	\begin{wrapfigure}[6]{r}[0pt]{6cm}

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -23,7 +23,7 @@
 
  As you read through this documentation, you'll occasionally see dates shown in the margin
  (for example, next to this paragraph!)
- \announce*{2017-06-25} which detail the date of the version in which the feature was implemented;
+ \announce{2017-06-25} which detail the date of the version in which the feature was implemented;
  the `N' stands for `new as of the date shown'. If you see a $\color{cmhgold}\bigstar$, it
  means that the feature is new as of the release of the current version.
 
@@ -45,7 +45,7 @@ latexindent.pl
 	and available options.
 
 \flagbox{-v, --version}
-	\announce*{2017-06-25}
+	\announce{2017-06-25}
 	\begin{commandshell}
 latexindent.pl -v
       \end{commandshell}
@@ -103,7 +103,7 @@ latexindent.pl myfile.tex > output.tex
 \end{commandshell}
 
 	You can call the \texttt{-o} switch with the name of the output file \emph{without} an extension; in
-	\announce*{2017-06-25}
+	\announce{2017-06-25}
 	this case, \texttt{latexindent.pl} will use the extension from the original file. For example,
 	the following two calls to \texttt{latexindent.pl} are equivalent:
 	\begin{commandshell}
@@ -112,7 +112,7 @@ latexindent.pl myfile.tex -o=output.tex
 \end{commandshell}
 
 	You can call the \texttt{-o} switch using a \texttt{+} symbol at the beginning; this will
-	\announce*{2017-06-25}
+	\announce{2017-06-25}
 	concatenate the name of the input file and the text given to the \texttt{-o} switch.
 	For example, the following two calls to \texttt{latexindent.pl} are equivalent:
 	\begin{commandshell}
@@ -121,7 +121,7 @@ latexindent.pl myfile.tex -o=myfilenew.tex
 \end{commandshell}
 
 	You can call the \texttt{-o} switch using a \texttt{++} symbol at the end of the name
-	\announce*{2017-06-25}
+	\announce{2017-06-25}
 	of your output file; this tells \texttt{latexindent.pl} to search successively for
 	the name of your output file concatenated with $0, 1, \ldots$ while the name of the
 	output file exists.  For example,
@@ -210,7 +210,7 @@ latexindent.pl myfile.tex -l=first.yaml,second.yaml,third.yaml
 	Explicit demonstrations of how to use the \texttt{-l} switch are given throughout this documentation.
 
 	You can call the \texttt{-l} switch with a `+' symbol either before or after
-	\announce*{2017-06-25}
+	\announce{2017-06-25}
 	another YAML file; for example:
 	\begin{commandshell}
 latexindent.pl -l=+myyaml.yaml  myfile.tex
@@ -234,7 +234,7 @@ latexindent.pl -l + myyaml.yaml myfile.tex
 	will \emph{only} load \texttt{localSettings.yaml}, and \texttt{myyaml.yaml} will be ignored.
 
 	You may also choose to omit the \texttt{yaml} extension, such as
-	\announce*{2017-06-25}
+	\announce{2017-06-25}
 	\begin{commandshell}
 latexindent.pl -l=localSettings,myyaml myfile.tex
     \end{commandshell}

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -292,8 +292,7 @@ latexindent.pl myfile
 
 \subsection{From \texttt{arara}}\label{sec:arara}
 	Using \texttt{latexindent.pl} from the command line is fine for some folks, but
-	others may find it easier to use from \texttt{arara}. \texttt{arara} ships with
-	a rule, \texttt{indent.yaml}, but in case you do not have this rule, you can find it at \cite{paulo}.
+	others may find it easier to use from \texttt{arara}; you can find the arara rule at \cite{paulo}.
 
 	You can use the rule in any of the ways described in \cref{lst:arara} (or combinations thereof).
 	In fact, \texttt{arara} allows yet greater flexibility -- you can use \texttt{yes/no}, \texttt{true/false}, or \texttt{on/off} to toggle the various options.
@@ -330,7 +329,7 @@ latexindent.pl myfile
 			\texttt{localSettings}            & \texttt{-l} \\
 			\texttt{onlyDefault}              & \texttt{-d} \\
 			\texttt{cruft}                    & \texttt{-c} \\
-			\texttt{modifylinebreaks}         & \texttt{-m} \\
+			%\texttt{modifylinebreaks}         & \texttt{-m} \\
 			\bottomrule
 		\end{tabular}
 	\end{table}

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -234,6 +234,7 @@ latexindent.pl -l + myyaml.yaml myfile.tex
 	will \emph{only} load \texttt{localSettings.yaml}, and \texttt{myyaml.yaml} will be ignored.
 
 	You may also choose to omit the \texttt{yaml} extension, such as
+	\announce*{2017-06-25}
 	\begin{commandshell}
 latexindent.pl -l=localSettings,myyaml myfile.tex
     \end{commandshell}

--- a/documentation/title.tex
+++ b/documentation/title.tex
@@ -1,0 +1,31 @@
+\title{%
+	\begin{tcolorbox}[
+			width=5.2cm,
+			boxrule=0pt,
+			colframe=white!40!black,
+			colback=white,
+			rightrule=2pt,
+			sharp corners,
+			enhanced,
+			overlay={\node[anchor=north east,outer sep=2pt] at ([xshift=3cm,yshift=4mm]frame.north east) {\includegraphics[width=3cm]{logo}}; }]
+		\centering\ttfamily\bfseries latexindent.pl\\[1cm] Version 3.2.2
+	\end{tcolorbox}
+}
+\author{Chris Hughes \thanks{and contributors! See \vref{sec:contributors}. For
+		all communication, please visit \cite{latexindent-home}.}}
+\maketitle
+\begin{adjustwidth}{1cm}{1cm}
+	\small
+	\texttt{latexindent.pl} is a \texttt{Perl} script that indents \texttt{.tex} (and other)
+	files according to an indentation scheme that the user can modify to suit their
+	taste. Environments, including those with alignment delimiters (such as \texttt{tabular}),
+	and commands, including those that can split braces and brackets across lines,
+	are \emph{usually} handled correctly by the script. Options for \texttt{verbatim}-like
+	environments and commands, together with indentation after headings (such as \lstinline!chapter!, \lstinline!section!, etc)
+	are also available. The script also has the ability to modifiy line breaks, and add
+	comment symbols. All user options are customisable via the switches in the YAML interface.
+\end{adjustwidth}
+\tableofcontents
+{\small
+	\lstlistoflistings
+}

--- a/helper-scripts/update-version.sh
+++ b/helper-scripts/update-version.sh
@@ -15,14 +15,15 @@ do
  esac 
 done
 
-oldVersion='3.2'
-newVersion='3.2.1'
-oldDate='2017-06-19'
-newDate='2017-06-25'
+oldVersion='3.2.1'
+newVersion='3.2.2'
+oldDate='2017-06-25'
+newDate='2017-06-28'
 
 cd ../
 cd documentation
-find -name "*.tex" -print0|xargs -0 sed -i.bak -E "s/announce\*\{NEW\}/announce\*\{$newDate\}/g"
+find -name "*.tex" -print0|xargs -0 sed -i.bak -E "s/announce\*\{/announce\{/g"
+find -name "*.tex" -print0|xargs -0 sed -i.bak -E "s/announce\{NEW\}/announce\*\{$newDate\}/g"
 cd ../
 sed -i.bak "s/\$versionNumber = '$oldVersion'/\$versionNumber = '$newVersion'/" LatexIndent/Version.pm
 sed -i.bak "s/\$versionDate = '$oldDate'/\$versionDate = '$newDate'/" LatexIndent/Version.pm
@@ -32,7 +33,7 @@ sed -i.bak "s/version $oldVersion/version $newVersion/" readme.md
 sed -i.bak "s/$oldDate/$newDate/" readme.md
 sed -i.bak "s/version $oldVersion/version $newVersion/" documentation/readme.txt
 sed -i.bak "s/$oldDate/$newDate/" documentation/readme.txt
-sed -i.bak "s/Version $oldVersion/Version $newVersion/" documentation/latexindent.tex
+sed -i.bak "s/Version $oldVersion/Version $newVersion/" documentation/title.tex
 # possibly generate the pdf
 [[ $generatePDFmode == 1 ]] && cd documentation && arara latexindent
 exit

--- a/latexindent.pl
+++ b/latexindent.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-#   latexindent.pl, version 3.2.1, 2017-06-25
+#   latexindent.pl, version 3.2.2, 2017-06-28
 #
 #	This program is free software: you can redistribute it and/or modify
 #	it under the terms of the GNU General Public License as published by

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,6 @@ environments in `.tex`files.
 Author: Chris Hughes (cmhughes)
 
 ---
----
 
 For complete details, please see documentation/latexindent.pdf
 
@@ -16,7 +15,7 @@ Note: `latexindent.exe` was created using
 
 using the `Par::Packer` perl module.
 
-ppp.pl is located in the helper-scripts directory.
+`ppp.pl` is located in the helper-scripts directory.
 
 ---
 
@@ -28,12 +27,12 @@ You'll need
         LatexIndent/*.pm
         defaultSettings.yaml
 
-in the same directory. Windows users might prefer to grab latexindent.exe
+in the same directory. Windows users might prefer to grab `latexindent.exe`
 
 ### Testing
 
 A nice way to test the script is to navigate to the test-cases 
-directory, and then run the command (on Linux/Mac -- sorry, not created a Windows test-case version):
+directory, and then run the command (on Linux/Mac -- sorry, a Windows test-case version is not available):
 
         ./test-cases.sh
 
@@ -44,8 +43,8 @@ recommend comparing the outputfile.tex to make sure that
 nothing has been changed (or removed) in a way that will damage
 your file.
 
-I recommend using both of the following:
+I recommend using each of the following:
 * a visual check, at the very least, make sure that 
       each file has the same number of lines
 * a check using `latexdiff inputfile.tex outputfile.tex`
-* git status myfile.tex
+* `git status` myfile.tex

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 `PERL` script to indent code within environments, and align delimited 
 environments in `.tex`files.
 
-    latexindent.pl, version 3.2.1, 2017-06-25
+    latexindent.pl, version 3.2.2, 2017-06-28
 
 Author: Chris Hughes (cmhughes)
 

--- a/test-cases/horizontalWhiteSpace/remove-TWS.yaml
+++ b/test-cases/horizontalWhiteSpace/remove-TWS.yaml
@@ -1,0 +1,1 @@
+removeTrailingWhitespace: 1

--- a/test-cases/horizontalWhiteSpace/remove-TWS1.yaml
+++ b/test-cases/horizontalWhiteSpace/remove-TWS1.yaml
@@ -1,0 +1,1 @@
+removeTrailingWhitespace: 0

--- a/test-cases/horizontalWhiteSpace/whitespace-rm-no.tex
+++ b/test-cases/horizontalWhiteSpace/whitespace-rm-no.tex
@@ -1,0 +1,4 @@
+here is some text          
+here is some text          
+here is some text          
+here is some text          

--- a/test-cases/horizontalWhiteSpace/whitespace-rm-yes.tex
+++ b/test-cases/horizontalWhiteSpace/whitespace-rm-yes.tex
@@ -1,0 +1,4 @@
+here is some text
+here is some text
+here is some text
+here is some text

--- a/test-cases/horizontalWhiteSpace/whitespace-test-cases.sh
+++ b/test-cases/horizontalWhiteSpace/whitespace-test-cases.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+loopmax=0
+. ../common.sh
+
+[[ $silentMode == 0 ]] && set -x 
+latexindent.pl -s whitespace -l=remove-TWS.yaml -o +-rm-yes
+latexindent.pl -s whitespace -l=remove-TWS1.yaml -o +-rm-no
+
+git status
+[[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/horizontalWhiteSpace/whitespace.tex
+++ b/test-cases/horizontalWhiteSpace/whitespace.tex
@@ -1,0 +1,4 @@
+here is some text          
+here is some text          
+here is some text          
+here is some text          

--- a/test-cases/test-cases.sh
+++ b/test-cases/test-cases.sh
@@ -125,6 +125,10 @@ cd ../maxLineChars
 cd ../texexchange
 [[ $silentMode == 1 ]] && echo "./texexchange/texexchange-test-cases.sh"
 ./texexchange-test-cases.sh $silentModeFlag $showCounterFlag $loopminFlag $noisyModeFlag
+# whitespace
+cd ../horizontalWhiteSpace
+[[ $silentMode == 1 ]] && echo "./horizontalWhiteSpace/whitespace-test-cases.sh"
+./whitespace-test-cases.sh $silentModeFlag $showCounterFlag $loopminFlag $noisyModeFlag
 # benchmark mode, if appropriate
 cd ../benchmarks
 [[ $benchmarkMode == 1 ]] && ./benchmarks.sh $silentModeFlag $showCounterFlag $loopminFlag $noisyModeFlag


### PR DESCRIPTION
This pull request represents a very small tweak to `LatexIndent/HorizontalWhiteSpace.pm` to account for the issue raised at https://github.com/Glavin001/atom-beautify/issues/1564.

Users can specify `removeTrailingWhitespace` as a scalar, for example
```
 removeTrailingWhitespace: 0
```
