### PR TITLE
Feature/maximum indentation

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -235,6 +235,9 @@ indentAfterHeadings:
        indentAfterThisHeading: 0
        level: 7
 
+# maximum indentation, off by default
+maximumIndentation: -1
+
 # if you don't want to have additional indentation 
 # in an environment put it in this hash table; note that
 # environments in this hash table will inherit 
@@ -304,9 +307,6 @@ commandCodeBlocks:
         decoration: 1
         ++: 1
         --: 1
-
-# maximum indentation
-maximumIndentation: -1
 
 # modifyLineBreaks will only be searched if the -m 
 # switch is active

--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -305,6 +305,9 @@ commandCodeBlocks:
         ++: 1
         --: 1
 
+# maximum indentation
+maximumIndentation: -1
+
 # modifyLineBreaks will only be searched if the -m 
 # switch is active
 #    BeginStartsOnOwnLine: 1

--- a/documentation/appendices.tex
+++ b/documentation/appendices.tex
@@ -15,6 +15,7 @@ use PerlIO::encoding;
 use Unicode::GCString;
 use open ':std', ':encoding(UTF-8)';
 use Text::Wrap;
+use Text::Tabs;
 use FindBin;
 use YAML::Tiny;
 use File::Copy;

--- a/documentation/demonstrations/documentation-test-cases.sh
+++ b/documentation/demonstrations/documentation-test-cases.sh
@@ -191,5 +191,9 @@ latexindent.pl -s shortlines-md.tex -o shortlines-md4.tex -l=remove-para4.yaml -
 latexindent.pl -s sl-stop.tex -o sl-stop4.tex -l=remove-para4.yaml -m
 latexindent.pl -s sl-stop.tex -o sl-stop4-command.tex -l=remove-para4.yaml,stop-command.yaml -m
 latexindent.pl -s sl-stop.tex -o sl-stop4-comment.tex -l=remove-para4.yaml,stop-comment.yaml -m
+
+# maximum indentation
+latexindent.pl -s mult-nested.tex -o=+-default
+latexindent.pl -s mult-nested.tex -l=max-indentation1 -o=+-max-ind1
 [[ $noisyMode == 1 ]] && makenoise
 git status

--- a/documentation/demonstrations/max-indentation1.yaml
+++ b/documentation/demonstrations/max-indentation1.yaml
@@ -1,0 +1,1 @@
+maximumIndentation: " "

--- a/documentation/demonstrations/mult-nested-default.tex
+++ b/documentation/demonstrations/mult-nested-default.tex
@@ -1,0 +1,12 @@
+\begin{one}
+	one
+	\begin{two}
+		two
+		\begin{three}
+			three
+			\begin{four}
+				four
+			\end{four}
+		\end{three}
+	\end{two}
+\end{one}

--- a/documentation/demonstrations/mult-nested-max-ind1.tex
+++ b/documentation/demonstrations/mult-nested-max-ind1.tex
@@ -1,0 +1,12 @@
+\begin{one}
+ one
+ \begin{two}
+ two
+ \begin{three}
+ three
+ \begin{four}
+ four
+ \end{four}
+ \end{three}
+ \end{two}
+\end{one}

--- a/documentation/demonstrations/mult-nested.tex
+++ b/documentation/demonstrations/mult-nested.tex
@@ -1,0 +1,12 @@
+\begin{one}
+one
+\begin{two}
+    two
+\begin{three}
+     three 
+\begin{four}
+       four
+\end{four}
+\end{three}
+\end{two}
+\end{one}

--- a/documentation/latex-indent.bib
+++ b/documentation/latex-indent.bib
@@ -28,3 +28,8 @@
 	url="http://perldoc.perl.org/Text/Wrap.html",
 	urldate={2017-05-01},
 }
+@online{texttabs,
+	title="Text::Tabs Perl module",
+	url="http://search.cpan.org/~muir/Text-Tabs+Wrap-2013.0523/lib.old/Text/Tabs.pm",
+	urldate={2017-07-06},
+}

--- a/documentation/latexindent.tex
+++ b/documentation/latexindent.tex
@@ -151,13 +151,13 @@
 	new-to-this-version/.style={
 			enhanced,
 			overlay={\node[cmhstar,scale=0.65] at ([yshift=0mm,xshift=0mm]frame.north east) {}; },
-            addtololstar,
+			addtololstar,
 		},
 }
 
 \newtcblisting[use counter=lstlisting]{cmhlistings}[3][]{%
 	cmhlistings,
-    addtolol,
+	addtolol,
 	center title,
 	title={\color{black}{\scshape Listing \thetcbcounter}: ~#2},label={#3},
 	listing engine=listings,

--- a/documentation/sec-default-user-local.tex
+++ b/documentation/sec-default-user-local.tex
@@ -474,6 +474,44 @@ latexindent.pl headings1.tex -l=headings1.yaml
 	you should receive the code given in \cref{lst:headings1-mod2}; notice that
 	the \texttt{paragraph} and \texttt{subsection} are at the same indentation level.
 
+\yamltitle{maximumIndentation}*{horizontal space}
+	You can control the maximum indentation given to your file by \announce{NEW}[maximumIndentation]
+	specifying the \texttt{maximumIndentation} field as horizontal space (but \emph{not} including tabs).
+	This feature uses the \texttt{Text::Tabs} module \cite{texttabs}, and is \emph{off}
+	by default.
+
+	For example, consider the example shown in \cref{lst:mult-nested} together with the default output
+	shown in \cref{lst:mult-nested-default}.
+
+	\begin{minipage}{.45\textwidth}
+		\cmhlistingsfromfile*{demonstrations/mult-nested.tex}{\texttt{mult-nested.tex}}{lst:mult-nested}
+	\end{minipage}%
+	\hfill
+	\begin{minipage}{.45\textwidth}
+		\cmhlistingsfromfile*{demonstrations/mult-nested-default.tex}{\texttt{mult-nested.tex} default output}{lst:mult-nested-default}
+	\end{minipage}
+
+	Now say that, for example, you have the \texttt{max-indentation1.yaml} from \cref{lst:max-indentation1yaml} and
+	that you run the following command:
+	\begin{commandshell}
+latexindent.pl mult-nested.tex -l=max-indentation1
+    \end{commandshell}
+	You should receive the output shown in \cref{lst:mult-nested-max-ind1}.
+
+	\begin{minipage}{.45\textwidth}
+		\cmhlistingsfromfile*[style=yaml-LST]{demonstrations/max-indentation1.yaml}[yaml-TCB]{\texttt{max-indentation1.yaml}}{lst:max-indentation1yaml}
+	\end{minipage}%
+	\hfill
+	\begin{minipage}{.45\textwidth}
+		\cmhlistingsfromfile*{demonstrations/mult-nested-max-ind1.tex}{\texttt{mult-nested.tex} using \cref{lst:max-indentation1yaml}}{lst:mult-nested-max-ind1}
+	\end{minipage}
+
+	Comparing the output in \cref{lst:mult-nested-default,lst:mult-nested-max-ind1} we notice that the (default) tabs
+	of indentation have been replaced by a single space.
+
+	In general, when using the \texttt{maximumIndentation} feature, any leading tabs will be replaced by equivalent
+	spaces except, of course, those found in \texttt{verbatimEnvironments} (see \vref{lst:verbatimEnvironments}) or \texttt{noIndentBlock} (see \vref{lst:noIndentBlock}).
+
 \subsection{The code blocks known \texttt{latexindent.pl}}\label{subsubsec:code-blocks}
 	As of Version 3.0, \texttt{latexindent.pl} processes documents using code blocks; each
 	of these are shown in \cref{tab:code-blocks}.

--- a/documentation/sec-introduction.tex
+++ b/documentation/sec-introduction.tex
@@ -52,7 +52,7 @@
 \subsection{About this documentation}
 	As you read through this documentation, you will see many listings; in this version of the documentation,
 	there are a total of \totallstlistings. This may seem a lot, but I deem it necessary in
-    presenting the various different options of \texttt{latexindent.pl} and the associated output that they are capable of
+	presenting the various different options of \texttt{latexindent.pl} and the associated output that they are capable of
 	producing.
 
 	The different listings are presented using different styles:
@@ -91,5 +91,5 @@
 	means that the feature is new as of the release of the current version; if you see \stardemo\,
 	attached to a listing, then it means that listing is new as of the current version. If you have
 	not read this document before (and even if you have!), then you can ignore every occurrence of the \stardemo;
-    they are simply there to highlight new features. 
+	they are simply there to highlight new features.
 	The new features in this documentation (\gitRel) are on the following pages: \listOfNewFeatures

--- a/test-cases/environments/environments-nested-fourth-max-indentation-mod1.tex
+++ b/test-cases/environments/environments-nested-fourth-max-indentation-mod1.tex
@@ -1,0 +1,28 @@
+here is a nested test
+\begin{one}
+ to be nested to be nested
+ to be nested to be nested
+ to be nested to be nested
+ \begin{two}
+ nested text nested tex nested tex
+ nested text nested tex nested tex
+ nested text nested tex nested tex
+ nested text nested tex nested tex
+ \begin{three}
+ triple nesting
+ triple nesting
+ triple nesting
+ triple nesting
+ triple nesting
+ triple nesting
+ \begin{four}
+ fourth nesting
+ fourth nesting
+ fourth nesting
+ fourth nesting
+ fourth nesting
+ fourth nesting
+ \end{four}
+ \end{three}
+ \end{two}
+\end{one}

--- a/test-cases/environments/environments-nested-fourth-max-indentation1.tex
+++ b/test-cases/environments/environments-nested-fourth-max-indentation1.tex
@@ -1,0 +1,24 @@
+here is a nested test
+\begin{one}
+ to be nested to be nested
+ to be nested to be nested
+ to be nested to be nested
+ \begin{two}
+ nested text nested tex nested tex
+ nested text nested tex nested tex
+ nested text nested tex nested tex
+ nested text nested tex nested tex
+ \begin{three}
+ triple nesting
+ triple nesting
+ triple nesting
+ triple nesting
+ triple nesting
+ triple nesting
+ \begin{four}
+ fourth nesting
+ fourth nesting
+ fourth nesting
+ fourth nesting
+ fourth nesting
+ fourth nesting \end{four} \end{three} \end{two} \end{one}

--- a/test-cases/environments/environments-nested-fourth-max-indentation2.tex
+++ b/test-cases/environments/environments-nested-fourth-max-indentation2.tex
@@ -1,0 +1,24 @@
+here is a nested test
+\begin{one}
+  to be nested to be nested
+  to be nested to be nested
+  to be nested to be nested
+  \begin{two}
+  nested text nested tex nested tex
+  nested text nested tex nested tex
+  nested text nested tex nested tex
+  nested text nested tex nested tex
+  \begin{three}
+  triple nesting
+  triple nesting
+  triple nesting
+  triple nesting
+  triple nesting
+  triple nesting
+  \begin{four}
+  fourth nesting
+  fourth nesting
+  fourth nesting
+  fourth nesting
+  fourth nesting
+  fourth nesting \end{four} \end{three} \end{two} \end{one}

--- a/test-cases/environments/environments-nested-fourth-max-indentation3.tex
+++ b/test-cases/environments/environments-nested-fourth-max-indentation3.tex
@@ -1,0 +1,24 @@
+here is a nested test
+\begin{one}
+   to be nested to be nested
+   to be nested to be nested
+   to be nested to be nested
+   \begin{two}
+   nested text nested tex nested tex
+   nested text nested tex nested tex
+   nested text nested tex nested tex
+   nested text nested tex nested tex
+   \begin{three}
+   triple nesting
+   triple nesting
+   triple nesting
+   triple nesting
+   triple nesting
+   triple nesting
+   \begin{four}
+   fourth nesting
+   fourth nesting
+   fourth nesting
+   fourth nesting
+   fourth nesting
+   fourth nesting \end{four} \end{three} \end{two} \end{one}

--- a/test-cases/environments/environments-nested-fourth-max-indentation4.tex
+++ b/test-cases/environments/environments-nested-fourth-max-indentation4.tex
@@ -1,0 +1,24 @@
+here is a nested test
+\begin{one}
+       to be nested to be nested
+       to be nested to be nested
+       to be nested to be nested
+       \begin{two}
+       nested text nested tex nested tex
+       nested text nested tex nested tex
+       nested text nested tex nested tex
+       nested text nested tex nested tex
+       \begin{three}
+       triple nesting
+       triple nesting
+       triple nesting
+       triple nesting
+       triple nesting
+       triple nesting
+       \begin{four}
+       fourth nesting
+       fourth nesting
+       fourth nesting
+       fourth nesting
+       fourth nesting
+       fourth nesting \end{four} \end{three} \end{two} \end{one}

--- a/test-cases/environments/environments-nested-fourth-max-indentation5.tex
+++ b/test-cases/environments/environments-nested-fourth-max-indentation5.tex
@@ -1,0 +1,24 @@
+here is a nested test
+\begin{one}
+        to be nested to be nested
+        to be nested to be nested
+        to be nested to be nested
+        \begin{two}
+         nested text nested tex nested tex
+         nested text nested tex nested tex
+         nested text nested tex nested tex
+         nested text nested tex nested tex
+         \begin{three}
+         triple nesting
+         triple nesting
+         triple nesting
+         triple nesting
+         triple nesting
+         triple nesting
+         \begin{four}
+         fourth nesting
+         fourth nesting
+         fourth nesting
+         fourth nesting
+         fourth nesting
+         fourth nesting \end{four} \end{three} \end{two} \end{one}

--- a/test-cases/environments/environments-test-cases.sh
+++ b/test-cases/environments/environments-test-cases.sh
@@ -79,6 +79,14 @@ do
    [[ $silentMode == 0 ]] && set +x 
 done
 
+# maximum indentation test cases
+latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation1.tex -l=max-indentation1.yaml
+latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation2.tex -l=max-indentation2.yaml
+latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation3.tex -l=max-indentation3.yaml
+latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation4.tex -l=max-indentation4.yaml
+latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation5.tex -l=max-indentation5.yaml
+latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation-mod1.tex -l=max-indentation1,env-mod-lines1 -m 
+
 [[ $silentMode == 0 ]] && set -x 
 
 

--- a/test-cases/environments/environments-test-cases.sh
+++ b/test-cases/environments/environments-test-cases.sh
@@ -86,6 +86,7 @@ latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation3.tex -l=ma
 latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation4.tex -l=max-indentation4.yaml
 latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation5.tex -l=max-indentation5.yaml
 latexindent.pl -s environments-nested-fourth.tex -o=+-max-indentation-mod1.tex -l=max-indentation1,env-mod-lines1 -m 
+latexindent.pl -s environments-verbatim-harder.tex -o=+-max-ind1 -l=max-indentation1.yaml
 
 [[ $silentMode == 0 ]] && set -x 
 

--- a/test-cases/environments/environments-verbatim-harder-max-ind1.tex
+++ b/test-cases/environments/environments-verbatim-harder-max-ind1.tex
@@ -1,0 +1,24 @@
+before minipage
+\begin{fig}
+ \begin{minipage}
+ \begin{verbatim}
+  to be nested to be nested
+          to be nested to be nested
+to be nested to be nested 
+
+		\end{verbatim}
+ \end{minipage}
+ \begin{minipage}
+ \begin{lstlisting}
+    here is some more verbatim
+            and a child environment
+         something else
+         \begin{myenv}
+            shouldn't
+       be
+                    touched
+            \end{myenv}
+		\end{lstlisting}
+ \end{minipage}
+\end{fig}
+after verbatim

--- a/test-cases/environments/max-indentation1.yaml
+++ b/test-cases/environments/max-indentation1.yaml
@@ -1,0 +1,1 @@
+maximumIndentation: " "

--- a/test-cases/environments/max-indentation2.yaml
+++ b/test-cases/environments/max-indentation2.yaml
@@ -1,0 +1,1 @@
+maximumIndentation: "  "

--- a/test-cases/environments/max-indentation3.yaml
+++ b/test-cases/environments/max-indentation3.yaml
@@ -1,0 +1,1 @@
+maximumIndentation: "   "

--- a/test-cases/environments/max-indentation4.yaml
+++ b/test-cases/environments/max-indentation4.yaml
@@ -1,0 +1,1 @@
+maximumIndentation: "       "

--- a/test-cases/environments/max-indentation5.yaml
+++ b/test-cases/environments/max-indentation5.yaml
@@ -1,0 +1,1 @@
+maximumIndentation: "         "

--- a/test-cases/keyEqualsValueBraces/hea-senior-fellowship-application-max-indentation.tex
+++ b/test-cases/keyEqualsValueBraces/hea-senior-fellowship-application-max-indentation.tex
@@ -1,0 +1,491 @@
+% dos2unix hea-senior-fellow.tex
+% arara: pdflatex: {shell: on}
+% arara: bibtex
+% arara: makeglossaries
+% arara: pdflatex: {shell: on}
+% arara: pdflatex: {shell: on}
+% !arara: indent: {overwrite: yes, trace: on}
+\documentclass[11pt,twoside]{article}
+\usepackage[headheight=14pt,left=4.5cm,right=2.0cm,showframe=false,
+ top=2cm,bottom=1.5cm,asymmetric=true,bindingoffset=0cm]{geometry}
+\usepackage{parskip}
+\usepackage{titlesec}                   % customize headings
+\usepackage{titletoc}                   % customize tableofcontents
+\usepackage{fancyhdr}                   % headers and footers
+\usepackage[charter]{mathdesign}        % font choice
+\usepackage{microtype}                  % better kerning
+\usepackage[backend=bibtex,maxnames=99]{biblatex}   % bibliography
+\usepackage[splitindex,nonewpage]{imakeidx}
+\usepackage{tcolorbox}
+
+\tcbuselibrary{breakable,skins}
+\usepackage{booktabs}
+\usepackage{pdfpages}
+%\usepackage[mark,grumpy]{gitinfo2}
+\usepackage{varioref}                   % good for referencing things 'far away'
+\usepackage{hyperref}                   % hyperlinks
+\usepackage[numbered]{bookmark}
+% load after hyperref: http://tex.stackexchange.com/questions/1863/which-packages-should-be-loaded-after-hyperref-instead-of-before
+\usepackage{cleveref}                   % allows \cref and friends
+\usepackage[section=subsection,toc,]{glossaries}
+\usepackage{glossary-longragged}
+\usepackage[numbered]{bookmark}
+
+% gitinfo2 settings
+%\renewcommand{\gitMark}{\gitBranch\,@\,\gitAbbrevHash{}\,\textbullet{}\,\gitAuthorDate}
+
+% hyperlink setup
+\hypersetup{
+ pdfauthor={Chris Hughes},
+ pdftitle={Senior Fellowship of HEA application},
+ pdfkeywords={HEA;senior fellowship},
+ bookmarksnumbered,
+ bookmarksopen,
+ linktocpage,
+ colorlinks=true,
+ linkcolor=blue,
+ citecolor=black,
+}
+
+% tcolorbox stuff
+\tcbset{
+ tocstyle/.style={
+ % used to surround the tocs (main and appendix)
+ breakable,enhanced,fonttitle=\bfseries\Large,
+ colback=gray!10,colframe=gray,%colframe=red!50!black,
+ before=\par\bigskip\noindent,
+ pad at break=3mm,
+ %left=0.75cm,
+ %enlargepage=2\baselineskip,
+ drop fuzzy shadow,
+ }
+}
+
+% bibliography settings
+\addbibresource{heabib}
+
+% cleveref settings
+\crefname{table}{Table}{Tables}
+\Crefname{table}{Table}{Tables}
+\crefname{figure}{Figure}{Figures}
+\Crefname{figure}{Figure}{Figures}
+\crefname{chapter}{Section}{Sections}
+\Crefname{chapter}{Section}{Sections}
+\crefname{section}{Section}{Sections}
+\Crefname{section}{Section}{Sections}
+\crefname{appendix}{Appendix}{Appendices}
+\Crefname{appendix}{Appendix}{Appendices}
+
+% index stuff
+% index stuff
+% index stuff
+% see http://tex.stackexchange.com/questions/130169/how-can-i-prevent-a-column-break-before-the-first-sub-entry-in-the-index
+\makeatletter
+% we don't want a page break before a subitem
+\renewcommand\subitem{\@idxitem\nobreak\hspace*{20\p@}}
+\makeindex
+\indexsetup{level=\section*,toclevel=subsection,noclearpage}
+\makeindex[intoc,name=practice,title=Practice -- what do we do]
+\makeindex[intoc,name=knowledge,title=Knowledge -- what we need to know]
+\makeindex[intoc,name=values,title=Values -- being professional]
+\makeindex[intoc,name=assessment,title=Senior Fellowship Assessment criteria]
+
+% glossaries settings
+% use longragged style, based on longtable
+\setglossarystyle{longragged}
+% widen description column
+\setlength{\glsdescwidth}{0.8\linewidth}
+% make entries bold and black
+\renewcommand{\glsnamefont}[1]{\textbf{#1}}
+\renewcommand*{\glstextformat}[1]{\textcolor{red}{#1}}
+
+% multiple glossaries, see http://texblog.org/2014/04/01/multiple-glossaries-in-latex/
+% practice -- what we do
+% practice -- what we do
+% practice -- what we do
+%	explain:	Where in my claim do I explain what I do?
+%	demonstrate: Where in my claim do I demonstrate how my expertise led me to choose these particular approaches to practice?
+%	critically evaluated: Where in my claim have I explained how I have critically evaluated these practices and, if appropriate, discussed how they could be further developed?
+\newglossary[prac-log]{practice}{practice-gls}{practice-glo}{Practice -- what we do}
+\newglossaryentry{practice:A1}{%
+ type=practice,
+ name=A1,
+ description={Design and plan learning activities and/or programmes of study}
+}
+\newglossaryentry{practice:A2}{%
+ type=practice,
+ name=A2,
+ description={Teach at a distance and/or support
+ distance and open learning}
+}
+\newglossaryentry{practice:A3}{%
+ type=practice,
+ name=A3,
+ description={Assess and give feedback to
+ learners}
+}
+\newglossaryentry{practice:A4}{%
+ type=practice,
+ name=A4,
+ description={Develop learning environments
+ that support open and distance
+ students to succeed}
+}
+\newglossaryentry{practice:A5}{%
+ type=practice,
+ name=A5,
+ description={Develop our understanding of our
+ subjects and how to teach them at a
+ distance, incorporating appropriate
+ subject research, professional
+ updating, educational scholarship and
+ reflection on our practice}
+}
+\newglossaryentry{practice:A6}{%
+ type=practice,
+ name=A6,
+ description={Work collaboratively within the
+ distributed OU community to support
+ the learning of students, our
+ colleagues and ourselves}
+}
+
+% knowledge -- what we need to know
+% knowledge -- what we need to know
+% knowledge -- what we need to know
+%	critically evaluate: Where in my claim do I critically evaluate how I have applied this knowledge in my practice?
+%	scholarship: Where in my claim have I explained how I have used scholarship (mine and others’) to develop my knowledge over time and the difference this has made to my practice?
+\newglossary[know-log]{knowledge}{know-gls}{know-glo}{Knowledge -- what we need to know}
+\newglossaryentry{knowledge:K1}{%
+ type=knowledge,
+ name=K1,
+ description={A sound grasp of the subjects or
+ topics we teach}
+}
+\newglossaryentry{knowledge:K2}{%
+ type=knowledge,
+ name=K2,
+ description={How to teach our subjects
+ effectively to support open and
+ distance learning}
+}
+\newglossaryentry{knowledge:K3}{%
+ type=knowledge,
+ name=K3,
+ description={How students learn at a distance,
+ both generally and within our subject}
+}
+\newglossaryentry{knowledge:K4}{%
+ type=knowledge,
+ name=K4,
+ description={How technologies can facilitate and
+ enhance distance and open learning}
+}
+\newglossaryentry{knowledge:K5}{%
+ type=knowledge,
+ name=K5,
+ description={How to evaluate our practice and
+ the learner experience, and the
+ effectiveness of teaching}
+}
+\newglossaryentry{knowledge:K6}{%
+ type=knowledge,
+ name=K6,
+ description={Why quality assurance and quality
+ enhancement matter for our work and
+ for the learner experience}
+}
+% values -- being professional
+% values -- being professional
+% values -- being professional
+%	inform: Where in my claim have I explained with examples how professional values inform my practice, enhance the learner experience and have affected the ways I work with and influence colleagues?
+\newglossary[values-log]{values}{values-gls}{values-glo}{Values -- being professional}
+\newglossaryentry{values:V1}{%
+ type=values,
+ name=V1,
+ description={ Putting students first, by respecting
+ individual learners and valuing diverse
+ and distributed learning communities}
+}
+\newglossaryentry{values:V2}{%
+ type=values,
+ name=V2,
+ description={Promoting participation in higher
+ education and equality of opportunity
+ by making learning accessible in open,
+ distance and virtual learning
+ environments}
+}
+\newglossaryentry{values:V3}{%
+ type=values,
+ name=V3,
+ description={Using evidence from research,
+ scholarship and our professional
+ development to underpin our
+ approaches to teaching and supporting
+ learning}
+}
+\newglossaryentry{values:V4}{%
+ type=values,
+ name=V4,
+ description={Recognising in our practice how
+ changing professional, cultural,
+ national and global factors affect
+ learners, as individuals, as citizens and
+ as employees}
+}
+% values -- being professional
+% values -- being professional
+% values -- being professional
+\newglossary[assessment-log]{assessment}{assessment-gls}{assessment-glo}{Senior Fellowship Assessment criteria}
+\newglossaryentry{assessment:D3.I.}{%
+ type=assessment,
+ name=D3.I.,
+ description={Successful engagement with each of the six Areas of Practice}
+}
+\newglossaryentry{assessment:D3.II.}{%
+ type=assessment,
+ name=D3.II.,
+ description={Your knowledge and understanding each of the six Knowledge elements}
+}
+\newglossaryentry{assessment:D3.III.}{%
+ type=assessment,
+ name=D3.III.,
+ description={Your commitment to all four Values in working with colleagues and facilitating learning}
+}
+\newglossaryentry{assessment:D3.IV.}{%
+ type=assessment,
+ name=D3.IV.,
+ description={Your successful engagement in appropriate teaching related to the Areas of Practice}
+}
+\newglossaryentry{assessment:D3.V.}{%
+ type=assessment,
+ name=D3.V.,
+ description={How professional practice, subject research and your own scholarly educational enquiry have shaped your approaches to teaching and supporting learning, as part of an integrated approach to academic practice}
+}
+\newglossaryentry{assessment:D3.VI.}{%
+ type=assessment,
+ name=D3.VI.,
+ description={Your successful engagement with appropriate professional development activity related to teaching, learning, assessment and other relevant responsibilities, and plans for your ongoing development}
+}
+\newglossaryentry{assessment:D3.VII.}{%
+ type=assessment,
+ name=D3.VII.,
+ description={Your successful co-ordination, support, supervision, management and/or mentoring of others (whether individuals or teams) in relation to teaching and learning }
+}
+\newglossaryentry{fix}{%
+ type=assessment,
+ name=fix,
+ description={\huge\color{red} !!!FIXTHIS present!!!}
+}
+% main glossary
+\newglossaryentry{SEaM}{%
+ type=main,
+ name=SEaM,
+ description={Student Experience on a Module}
+}
+\newglossaryentry{TMA}{%
+ type=main,
+ name=TMA,
+ description={Tutor Marked Assignments}
+}
+\newglossaryentry{eTMA}{%
+ type=main,
+ name=eTMA,
+ description={electronic Tutor Marked Assignments}
+}
+\newglossaryentry{iCMA}{%
+ type=main,
+ name=iCMA,
+ description={interactive Computer Marked Assignment}
+}
+\newglossaryentry{OU}{%
+ type=main,
+ name=OU,
+ description={The Open University}
+}
+\newglossaryentry{CDSA}{%
+ type=main,
+ name=CDSA,
+ description={Career Development and Staffing Appraisal}
+}
+\newglossaryentry{AL}{%
+ type=main,
+ name=AL,
+ description={Associate Lecturer (synonymous with tutor)}
+}
+\newglossaryentry{STEM}{%
+ type=main,
+ name=STEM,
+ description={Science Technology Engineering and Maths}
+}
+\newglossaryentry{LTS}{%
+ type=main,
+ name=LTS,
+ description={Learning and Teaching Solutions},
+}
+\newglossaryentry{PT3}{%
+ type=main,
+ name=PT3,
+ description={Form upon which tutors give summary feedback to students}
+}
+\newglossaryentry{SRPP}{%
+ type=main,
+ name=SRPP,
+ description={Student Research Project Panel},
+}
+\newglossaryentry{ALSD}{%
+ type=main,
+ name=ALSD,
+ description={AL Staff Development},
+}
+\newglossaryentry{APPLAuD}{%
+ type=main,
+ name=APPLAuD,
+ description={Accrediting \& Promoting Professional Learning \& Academic Development },
+}
+
+\makeglossaries
+
+% Define fix command
+% 	- it puts a comment in the margin
+% 	- it writes to a file with a list of things that need fixing
+\newcommand{\fixthis}[1]
+{%
+ \marginpar{\huge \color{red}FIX!}%
+ \typeout{FIXTHIS: p\thepage : #1^^J}%
+ \gls{fix}
+}
+
+% heading settings
+% heading settings
+% heading settings
+
+% from the titlesec package
+%\titleformat{ command }
+%             [ shape ]
+%             { format }{ label }{ sep }{ before-code }[ after-code ]
+% custom section
+\titleformat{\section}
+{\normalfont\Large\bfseries}
+{\makebox[0pt][r]{\thesection\hspace{.5cm}}}
+{0pt}
+{}
+
+% custom subsection
+\titleformat{\subsection}
+{\normalfont\large\bfseries}
+{\makebox[0pt][r]{\thesubsection\hspace{.5cm}}}
+{0pt}
+{}
+
+% custom subsubsection
+\titleformat{\subsubsection}
+{\normalfont\bfseries}
+{\makebox[0pt][r]{\thesubsubsection\hspace{.5cm}}}
+{0pt}
+{}
+
+% custom paragraph heading
+\titleformat{\paragraph}[leftmargin]
+{\normalfont
+ \scshape\filleft}
+{}
+{0pt}
+{}
+
+% spacing around headings
+% From the titlesec package
+% \titlespacing{command}{left spacing}{before spacing}{after spacing}[right]
+% spacing: how to read {12pt plus 4pt minus 2pt}
+%           12pt is what we would like the spacing to be
+%           plus 4pt means that TeX can stretch it by at most 4pt
+%           minus 2pt means that TeX can shrink it by at most 2pt
+%       This is one example of the concept of, 'glue', in TeX
+\titlespacing\section{0pt}{12pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing\subsection{0pt}{12pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing\subsubsection{0pt}{-3pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing{\paragraph}{6pc}{1.5ex plus .1ex minus .2ex}{1pc}
+
+% toc settings
+\titlecontents*{paragraph}% <paragaph>
+[3cm]% <left>
+{\small\itshape}% <above-code>
+{}% <numbered-entry-format>; you could also use {\thecontentslabel. } to show the numbers
+{}% <numberless-entry-format>
+{\ \thecontentspage}% <filler-page-format>
+[,\ ]% <separator>
+[]% <end>
+
+% headers and footers
+\fancyhf{} % delete current header and footer
+\fancyhead[LE,RO]{\bfseries\thepage}
+\fancyhead[LO,RE]{\leftmark}
+\fancyheadoffset[LE,LO]{3cm}
+\pagestyle{fancy}
+
+% map command
+\newcommand{\map}[1]{%
+ % #1 is a comma separated list
+ % with
+ %	a/b/c, a1/b1/c1, etc
+ % a: practice/knowledge/value
+ % b: A1--A6, K1--K6, etc
+ % c: explain/demonstrate/critically evaluate, etc
+ (\foreach \practice/\principle/\explain [count=\ni] in {#1}{%
+ \index[\practice]{\principle!\explain}%
+ \ifnum\ni=1% first entry does not get preceeding commas
+ \else% subsequent entries do
+ \nobreak,\,\nobreak
+ \fi%
+ \gls{\practice:\principle}%
+ })%
+}
+
+% graphics path
+\graphicspath{{./images/}}
+
+
+\begin{document}
+
+% add a bookmark for the toc
+\subpdfbookmark{Title page}{Title Page}
+\includepdf{images/titlepage}
+
+% add a bookmark for the toc
+\currentpdfbookmark{\contentsname{} and glossaries}{Contents}
+\setcounter{tocdepth}{5}
+\begin{tcolorbox}[tocstyle,
+ title={Contents},
+ %watermark text={\bfseries\Large Contents},
+ %watermark color=yellow!75!red!25!white,
+ ]
+ \makeatletter
+ \@starttoc{toc}
+ \makeatother
+\end{tcolorbox}
+
+\printglossary[type=main]
+\subsection*{\gls{APPLAuD} Principles -- Dimensions of Practice}
+Each of the following principles will be referenced throughout the document that follows; page references (which are hyper-links when viewed on screen) are given by each principle.
+\printglossary[type=practice]
+\printglossary[type=knowledge]
+\clearpage
+\printglossary[type=values]
+\printglossary[type=assessment]
+
+\input{primary-evidence}
+\input{cpd-plan}
+
+\printbibliography[title={References},notkeyword=institution,notkeyword=link,heading=bibintoc]
+\printbibliography[title={Links},keyword=link,heading=bibintoc]
+\printbibliography[title={Institutions at which I have worked},keyword=institution,heading=bibintoc]
+
+\clearpage
+%\currentpdfbookmark{Mapping tool}{Indices}
+\addcontentsline{toc}{section}{Mapping tool}
+\printindex[practice]
+\printindex[knowledge]
+\printindex[values]
+\printindex[assessment]
+\end{document}

--- a/test-cases/keyEqualsValueBraces/hea-senior-fellowship-application-max-indentation5.tex
+++ b/test-cases/keyEqualsValueBraces/hea-senior-fellowship-application-max-indentation5.tex
@@ -1,0 +1,491 @@
+% dos2unix hea-senior-fellow.tex
+% arara: pdflatex: {shell: on}
+% arara: bibtex
+% arara: makeglossaries
+% arara: pdflatex: {shell: on}
+% arara: pdflatex: {shell: on}
+% !arara: indent: {overwrite: yes, trace: on}
+\documentclass[11pt,twoside]{article}
+\usepackage[headheight=14pt,left=4.5cm,right=2.0cm,showframe=false,
+        top=2cm,bottom=1.5cm,asymmetric=true,bindingoffset=0cm]{geometry}
+\usepackage{parskip}
+\usepackage{titlesec}                   % customize headings
+\usepackage{titletoc}                   % customize tableofcontents
+\usepackage{fancyhdr}                   % headers and footers
+\usepackage[charter]{mathdesign}        % font choice
+\usepackage{microtype}                  % better kerning
+\usepackage[backend=bibtex,maxnames=99]{biblatex}   % bibliography
+\usepackage[splitindex,nonewpage]{imakeidx}
+\usepackage{tcolorbox}
+
+\tcbuselibrary{breakable,skins}
+\usepackage{booktabs}
+\usepackage{pdfpages}
+%\usepackage[mark,grumpy]{gitinfo2}
+\usepackage{varioref}                   % good for referencing things 'far away'
+\usepackage{hyperref}                   % hyperlinks
+\usepackage[numbered]{bookmark}
+% load after hyperref: http://tex.stackexchange.com/questions/1863/which-packages-should-be-loaded-after-hyperref-instead-of-before
+\usepackage{cleveref}                   % allows \cref and friends
+\usepackage[section=subsection,toc,]{glossaries}
+\usepackage{glossary-longragged}
+\usepackage[numbered]{bookmark}
+
+% gitinfo2 settings
+%\renewcommand{\gitMark}{\gitBranch\,@\,\gitAbbrevHash{}\,\textbullet{}\,\gitAuthorDate}
+
+% hyperlink setup
+\hypersetup{
+        pdfauthor={Chris Hughes},
+        pdftitle={Senior Fellowship of HEA application},
+        pdfkeywords={HEA;senior fellowship},
+        bookmarksnumbered,
+        bookmarksopen,
+        linktocpage,
+        colorlinks=true,
+        linkcolor=blue,
+        citecolor=black,
+}
+
+% tcolorbox stuff
+\tcbset{
+        tocstyle/.style={
+         % used to surround the tocs (main and appendix)
+         breakable,enhanced,fonttitle=\bfseries\Large,
+         colback=gray!10,colframe=gray,%colframe=red!50!black,
+         before=\par\bigskip\noindent,
+         pad at break=3mm,
+         %left=0.75cm,
+         %enlargepage=2\baselineskip,
+         drop fuzzy shadow,
+         }
+}
+
+% bibliography settings
+\addbibresource{heabib}
+
+% cleveref settings
+\crefname{table}{Table}{Tables}
+\Crefname{table}{Table}{Tables}
+\crefname{figure}{Figure}{Figures}
+\Crefname{figure}{Figure}{Figures}
+\crefname{chapter}{Section}{Sections}
+\Crefname{chapter}{Section}{Sections}
+\crefname{section}{Section}{Sections}
+\Crefname{section}{Section}{Sections}
+\crefname{appendix}{Appendix}{Appendices}
+\Crefname{appendix}{Appendix}{Appendices}
+
+% index stuff
+% index stuff
+% index stuff
+% see http://tex.stackexchange.com/questions/130169/how-can-i-prevent-a-column-break-before-the-first-sub-entry-in-the-index
+\makeatletter
+% we don't want a page break before a subitem
+\renewcommand\subitem{\@idxitem\nobreak\hspace*{20\p@}}
+\makeindex
+\indexsetup{level=\section*,toclevel=subsection,noclearpage}
+\makeindex[intoc,name=practice,title=Practice -- what do we do]
+\makeindex[intoc,name=knowledge,title=Knowledge -- what we need to know]
+\makeindex[intoc,name=values,title=Values -- being professional]
+\makeindex[intoc,name=assessment,title=Senior Fellowship Assessment criteria]
+
+% glossaries settings
+% use longragged style, based on longtable
+\setglossarystyle{longragged}
+% widen description column
+\setlength{\glsdescwidth}{0.8\linewidth}
+% make entries bold and black
+\renewcommand{\glsnamefont}[1]{\textbf{#1}}
+\renewcommand*{\glstextformat}[1]{\textcolor{red}{#1}}
+
+% multiple glossaries, see http://texblog.org/2014/04/01/multiple-glossaries-in-latex/
+% practice -- what we do
+% practice -- what we do
+% practice -- what we do
+%	explain:	Where in my claim do I explain what I do?
+%	demonstrate: Where in my claim do I demonstrate how my expertise led me to choose these particular approaches to practice?
+%	critically evaluated: Where in my claim have I explained how I have critically evaluated these practices and, if appropriate, discussed how they could be further developed?
+\newglossary[prac-log]{practice}{practice-gls}{practice-glo}{Practice -- what we do}
+\newglossaryentry{practice:A1}{%
+        type=practice,
+        name=A1,
+        description={Design and plan learning activities and/or programmes of study}
+}
+\newglossaryentry{practice:A2}{%
+        type=practice,
+        name=A2,
+        description={Teach at a distance and/or support
+         distance and open learning}
+}
+\newglossaryentry{practice:A3}{%
+        type=practice,
+        name=A3,
+        description={Assess and give feedback to
+         learners}
+}
+\newglossaryentry{practice:A4}{%
+        type=practice,
+        name=A4,
+        description={Develop learning environments
+         that support open and distance
+         students to succeed}
+}
+\newglossaryentry{practice:A5}{%
+        type=practice,
+        name=A5,
+        description={Develop our understanding of our
+         subjects and how to teach them at a
+         distance, incorporating appropriate
+         subject research, professional
+         updating, educational scholarship and
+         reflection on our practice}
+}
+\newglossaryentry{practice:A6}{%
+        type=practice,
+        name=A6,
+        description={Work collaboratively within the
+         distributed OU community to support
+         the learning of students, our
+         colleagues and ourselves}
+}
+
+% knowledge -- what we need to know
+% knowledge -- what we need to know
+% knowledge -- what we need to know
+%	critically evaluate: Where in my claim do I critically evaluate how I have applied this knowledge in my practice?
+%	scholarship: Where in my claim have I explained how I have used scholarship (mine and others’) to develop my knowledge over time and the difference this has made to my practice?
+\newglossary[know-log]{knowledge}{know-gls}{know-glo}{Knowledge -- what we need to know}
+\newglossaryentry{knowledge:K1}{%
+        type=knowledge,
+        name=K1,
+        description={A sound grasp of the subjects or
+         topics we teach}
+}
+\newglossaryentry{knowledge:K2}{%
+        type=knowledge,
+        name=K2,
+        description={How to teach our subjects
+         effectively to support open and
+         distance learning}
+}
+\newglossaryentry{knowledge:K3}{%
+        type=knowledge,
+        name=K3,
+        description={How students learn at a distance,
+         both generally and within our subject}
+}
+\newglossaryentry{knowledge:K4}{%
+        type=knowledge,
+        name=K4,
+        description={How technologies can facilitate and
+         enhance distance and open learning}
+}
+\newglossaryentry{knowledge:K5}{%
+        type=knowledge,
+        name=K5,
+        description={How to evaluate our practice and
+         the learner experience, and the
+         effectiveness of teaching}
+}
+\newglossaryentry{knowledge:K6}{%
+        type=knowledge,
+        name=K6,
+        description={Why quality assurance and quality
+         enhancement matter for our work and
+         for the learner experience}
+}
+% values -- being professional
+% values -- being professional
+% values -- being professional
+%	inform: Where in my claim have I explained with examples how professional values inform my practice, enhance the learner experience and have affected the ways I work with and influence colleagues?
+\newglossary[values-log]{values}{values-gls}{values-glo}{Values -- being professional}
+\newglossaryentry{values:V1}{%
+        type=values,
+        name=V1,
+        description={ Putting students first, by respecting
+         individual learners and valuing diverse
+         and distributed learning communities}
+}
+\newglossaryentry{values:V2}{%
+        type=values,
+        name=V2,
+        description={Promoting participation in higher
+         education and equality of opportunity
+         by making learning accessible in open,
+         distance and virtual learning
+         environments}
+}
+\newglossaryentry{values:V3}{%
+        type=values,
+        name=V3,
+        description={Using evidence from research,
+         scholarship and our professional
+         development to underpin our
+         approaches to teaching and supporting
+         learning}
+}
+\newglossaryentry{values:V4}{%
+        type=values,
+        name=V4,
+        description={Recognising in our practice how
+         changing professional, cultural,
+         national and global factors affect
+         learners, as individuals, as citizens and
+         as employees}
+}
+% values -- being professional
+% values -- being professional
+% values -- being professional
+\newglossary[assessment-log]{assessment}{assessment-gls}{assessment-glo}{Senior Fellowship Assessment criteria}
+\newglossaryentry{assessment:D3.I.}{%
+        type=assessment,
+        name=D3.I.,
+        description={Successful engagement with each of the six Areas of Practice}
+}
+\newglossaryentry{assessment:D3.II.}{%
+        type=assessment,
+        name=D3.II.,
+        description={Your knowledge and understanding each of the six Knowledge elements}
+}
+\newglossaryentry{assessment:D3.III.}{%
+        type=assessment,
+        name=D3.III.,
+        description={Your commitment to all four Values in working with colleagues and facilitating learning}
+}
+\newglossaryentry{assessment:D3.IV.}{%
+        type=assessment,
+        name=D3.IV.,
+        description={Your successful engagement in appropriate teaching related to the Areas of Practice}
+}
+\newglossaryentry{assessment:D3.V.}{%
+        type=assessment,
+        name=D3.V.,
+        description={How professional practice, subject research and your own scholarly educational enquiry have shaped your approaches to teaching and supporting learning, as part of an integrated approach to academic practice}
+}
+\newglossaryentry{assessment:D3.VI.}{%
+        type=assessment,
+        name=D3.VI.,
+        description={Your successful engagement with appropriate professional development activity related to teaching, learning, assessment and other relevant responsibilities, and plans for your ongoing development}
+}
+\newglossaryentry{assessment:D3.VII.}{%
+        type=assessment,
+        name=D3.VII.,
+        description={Your successful co-ordination, support, supervision, management and/or mentoring of others (whether individuals or teams) in relation to teaching and learning }
+}
+\newglossaryentry{fix}{%
+        type=assessment,
+        name=fix,
+        description={\huge\color{red} !!!FIXTHIS present!!!}
+}
+% main glossary
+\newglossaryentry{SEaM}{%
+        type=main,
+        name=SEaM,
+        description={Student Experience on a Module}
+}
+\newglossaryentry{TMA}{%
+        type=main,
+        name=TMA,
+        description={Tutor Marked Assignments}
+}
+\newglossaryentry{eTMA}{%
+        type=main,
+        name=eTMA,
+        description={electronic Tutor Marked Assignments}
+}
+\newglossaryentry{iCMA}{%
+        type=main,
+        name=iCMA,
+        description={interactive Computer Marked Assignment}
+}
+\newglossaryentry{OU}{%
+        type=main,
+        name=OU,
+        description={The Open University}
+}
+\newglossaryentry{CDSA}{%
+        type=main,
+        name=CDSA,
+        description={Career Development and Staffing Appraisal}
+}
+\newglossaryentry{AL}{%
+        type=main,
+        name=AL,
+        description={Associate Lecturer (synonymous with tutor)}
+}
+\newglossaryentry{STEM}{%
+        type=main,
+        name=STEM,
+        description={Science Technology Engineering and Maths}
+}
+\newglossaryentry{LTS}{%
+        type=main,
+        name=LTS,
+        description={Learning and Teaching Solutions},
+}
+\newglossaryentry{PT3}{%
+        type=main,
+        name=PT3,
+        description={Form upon which tutors give summary feedback to students}
+}
+\newglossaryentry{SRPP}{%
+        type=main,
+        name=SRPP,
+        description={Student Research Project Panel},
+}
+\newglossaryentry{ALSD}{%
+        type=main,
+        name=ALSD,
+        description={AL Staff Development},
+}
+\newglossaryentry{APPLAuD}{%
+        type=main,
+        name=APPLAuD,
+        description={Accrediting \& Promoting Professional Learning \& Academic Development },
+}
+
+\makeglossaries
+
+% Define fix command
+% 	- it puts a comment in the margin
+% 	- it writes to a file with a list of things that need fixing
+\newcommand{\fixthis}[1]
+{%
+        \marginpar{\huge \color{red}FIX!}%
+        \typeout{FIXTHIS: p\thepage : #1^^J}%
+        \gls{fix}
+}
+
+% heading settings
+% heading settings
+% heading settings
+
+% from the titlesec package
+%\titleformat{ command }
+%             [ shape ]
+%             { format }{ label }{ sep }{ before-code }[ after-code ]
+% custom section
+\titleformat{\section}
+{\normalfont\Large\bfseries}
+{\makebox[0pt][r]{\thesection\hspace{.5cm}}}
+{0pt}
+{}
+
+% custom subsection
+\titleformat{\subsection}
+{\normalfont\large\bfseries}
+{\makebox[0pt][r]{\thesubsection\hspace{.5cm}}}
+{0pt}
+{}
+
+% custom subsubsection
+\titleformat{\subsubsection}
+{\normalfont\bfseries}
+{\makebox[0pt][r]{\thesubsubsection\hspace{.5cm}}}
+{0pt}
+{}
+
+% custom paragraph heading
+\titleformat{\paragraph}[leftmargin]
+{\normalfont
+        \scshape\filleft}
+{}
+{0pt}
+{}
+
+% spacing around headings
+% From the titlesec package
+% \titlespacing{command}{left spacing}{before spacing}{after spacing}[right]
+% spacing: how to read {12pt plus 4pt minus 2pt}
+%           12pt is what we would like the spacing to be
+%           plus 4pt means that TeX can stretch it by at most 4pt
+%           minus 2pt means that TeX can shrink it by at most 2pt
+%       This is one example of the concept of, 'glue', in TeX
+\titlespacing\section{0pt}{12pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing\subsection{0pt}{12pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing\subsubsection{0pt}{-3pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing{\paragraph}{6pc}{1.5ex plus .1ex minus .2ex}{1pc}
+
+% toc settings
+\titlecontents*{paragraph}% <paragaph>
+[3cm]% <left>
+{\small\itshape}% <above-code>
+{}% <numbered-entry-format>; you could also use {\thecontentslabel. } to show the numbers
+{}% <numberless-entry-format>
+{\ \thecontentspage}% <filler-page-format>
+[,\ ]% <separator>
+[]% <end>
+
+% headers and footers
+\fancyhf{} % delete current header and footer
+\fancyhead[LE,RO]{\bfseries\thepage}
+\fancyhead[LO,RE]{\leftmark}
+\fancyheadoffset[LE,LO]{3cm}
+\pagestyle{fancy}
+
+% map command
+\newcommand{\map}[1]{%
+        % #1 is a comma separated list
+        % with
+        %	a/b/c, a1/b1/c1, etc
+        % a: practice/knowledge/value
+        % b: A1--A6, K1--K6, etc
+        % c: explain/demonstrate/critically evaluate, etc
+        (\foreach \practice/\principle/\explain [count=\ni] in {#1}{%
+         \index[\practice]{\principle!\explain}%
+         \ifnum\ni=1% first entry does not get preceeding commas
+         \else% subsequent entries do
+         \nobreak,\,\nobreak
+         \fi%
+         \gls{\practice:\principle}%
+         })%
+}
+
+% graphics path
+\graphicspath{{./images/}}
+
+
+\begin{document}
+
+% add a bookmark for the toc
+\subpdfbookmark{Title page}{Title Page}
+\includepdf{images/titlepage}
+
+% add a bookmark for the toc
+\currentpdfbookmark{\contentsname{} and glossaries}{Contents}
+\setcounter{tocdepth}{5}
+\begin{tcolorbox}[tocstyle,
+         title={Contents},
+         %watermark text={\bfseries\Large Contents},
+         %watermark color=yellow!75!red!25!white,
+        ]
+        \makeatletter
+        \@starttoc{toc}
+        \makeatother
+\end{tcolorbox}
+
+\printglossary[type=main]
+\subsection*{\gls{APPLAuD} Principles -- Dimensions of Practice}
+Each of the following principles will be referenced throughout the document that follows; page references (which are hyper-links when viewed on screen) are given by each principle.
+\printglossary[type=practice]
+\printglossary[type=knowledge]
+\clearpage
+\printglossary[type=values]
+\printglossary[type=assessment]
+
+\input{primary-evidence}
+\input{cpd-plan}
+
+\printbibliography[title={References},notkeyword=institution,notkeyword=link,heading=bibintoc]
+\printbibliography[title={Links},keyword=link,heading=bibintoc]
+\printbibliography[title={Institutions at which I have worked},keyword=institution,heading=bibintoc]
+
+\clearpage
+%\currentpdfbookmark{Mapping tool}{Indices}
+\addcontentsline{toc}{section}{Mapping tool}
+\printindex[practice]
+\printindex[knowledge]
+\printindex[values]
+\printindex[assessment]
+\end{document}

--- a/test-cases/keyEqualsValueBraces/key-equals-values-test-cases.sh
+++ b/test-cases/keyEqualsValueBraces/key-equals-values-test-cases.sh
@@ -74,6 +74,8 @@ latexindent.pl -s tikz2.tex -o tikz2-default.tex
 # hea files
 latexindent.pl -s heabib.bib -o heabib-default.bib
 latexindent.pl -s hea-senior-fellowship-application.tex -o hea-senior-fellowship-application-default.tex -l=../filecontents/indentPreambleYes.yaml
+latexindent.pl -s hea-senior-fellowship-application.tex -o=+-max-indentation -l=../filecontents/indentPreambleYes.yaml,../environments/max-indentation1.yaml
+latexindent.pl -s hea-senior-fellowship-application.tex -o=+-max-indentation5 -l=../filecontents/indentPreambleYes.yaml,../environments/max-indentation5.yaml
 # double back slash dodge, motivated by texexchange/29293-christian-feuersanger.tex
 latexindent.pl -s dodge-double-back-slash.tex -o dodge-double-back-slash-default.tex
 git status

--- a/test-cases/texexchange/pcc-pr-max-indentation.tex
+++ b/test-cases/texexchange/pcc-pr-max-indentation.tex
@@ -1,0 +1,717 @@
+% arara: pdflatex
+% arara: bibtex
+% arara: makeglossaries
+% arara: pdflatex
+% arara: pdflatex
+% !arara: indent: {overwrite: yes, trace: on}
+\documentclass[11pt,twoside]{report}
+%= == == == == == == == == == == =
+%
+% Document details: Program review for the mathematics department
+%       at Portland Community College, Portland OR
+%
+%       Prepared in Fall 2013, Winter 2014
+%
+%= == == == == == == == == == == =
+% binding offset was originally set to 1cm- killed it to 0cm as 
+% we were told that most folks won't print it.
+\usepackage[headheight=14pt,left=3.5cm,right=2.0cm,showframe=false,
+ top=2cm,bottom=1.5cm,asymmetric=true,bindingoffset=0cm]{geometry}
+\usepackage{parskip}
+\usepackage{titlesec}                   % customize headings
+\usepackage{titletoc}                   % customize tableofcontents
+\usepackage{multirow}                   % multirows in tables
+\usepackage{booktabs}                   % beautiful tables
+\usepackage{multicol}           % multicols environment
+\usepackage[super]{nth}                 % \nth{1} etc for 1st etc
+\usepackage{flafter}                    % floats won't appear until after they appear in the code
+\usepackage[figuresright]{rotating}     % sideways table
+\usepackage{longtable}                  % tables that can break across pages
+\usepackage{tabularx}
+\usepackage{fancyhdr}                   % headers and footers
+\usepackage{standalone}                 % maintain graphs and tables in separate files
+\usepackage{pdfpages}                   % include separate pdf documents
+\usepackage{enumitem}                   % customization of list environments
+\usepackage{changepage}                 % adjust margins for selected portions
+\usepackage{tablefootnote}              % footnotes within tables
+\usepackage[sc,hang]{caption}           % customize captions of tables and figures
+\usepackage{subcaption}                 % subfigures and subtables
+\usepackage[charter]{mathdesign}        % font choice
+\usepackage{microtype}                  % better kerning
+\usepackage{siunitx}                    % elegant handling of units
+\usepackage{pgfplotstable}              % typeset tables intelligently
+\usetikzlibrary{shapes}
+\usetikzlibrary{positioning}
+\usepackage{afterpage}                  %helps with rotating the pdf by 90 deg for sideways tables
+\usepackage{colortbl}                                                                           % row colours in tables
+\usepackage{tcolorbox}
+\usepackage{etoolbox}
+\usepackage{epigraph}                   % for inspirational quotes
+\usepackage[backend=bibtex,maxnames=99]{biblatex}   % bibliography
+\usepackage{varioref}                   % good for referencing things 'far away'
+\usepackage{hyperref}                   % hyperlinks
+\usepackage{pdfcomment}         % for inserting of tooltips, like with fix this items
+\usepackage[numbered]{bookmark}
+\usepackage{cleveref}                   % allows \cref and friends
+% fairwell refcheck- you have served us well
+%\usepackage{refcheck}                   % checks if labels have been used remove once the document is completed
+%\usepackage[left]{showlabels}
+%\showlabels{hypertarget}
+%\showlabels{hyperlink}
+
+% tcolorbox libraries
+\tcbuselibrary{breakable,skins}
+
+% hyperlink setup
+\hypersetup{colorlinks=true,
+ linkcolor=blue,
+ citecolor=black,
+}
+
+% bibliography settings
+\addbibresource{pccbib}
+
+% cleveref settings
+\crefname{table}{Table}{Tables}
+\Crefname{table}{Table}{Tables}
+\crefname{figure}{Figure}{Figures}
+\Crefname{figure}{Figure}{Figures}
+\crefname{chapter}{Section}{Sections}
+\Crefname{chapter}{Section}{Sections}
+\crefname{section}{Section}{Sections}
+\Crefname{section}{Section}{Sections}
+\crefname{appendix}{Appendix}{Appendices}
+\Crefname{appendix}{Appendix}{Appendices}
+
+% graphics path
+\graphicspath{{./graphics/}}
+
+% axis style, ticks, etc
+\pgfplotsset{every axis/.append style={
+ legend cell align=left,       % otherwise width won't be as intended: http://tex.stackexchange.com/questions/36297/pgfplots-how-can-i-scale-to-text-width
+ }}
+
+% percentage style for tables
+\pgfplotstableset{percentstyle/.style={
+ preproc/expr={##1*100},
+ dec sep align,fixed,fixed zerofill,
+ postproc cell content/.append code={
+ \ifx\\##1\\% check if ##1 is empty
+ \else
+ \ifnum1=\pgfplotstablepartno
+ \pgfkeysalso{@cell content/.add={}{\,\%}}%
+ \fi
+ \fi
+ },
+ precision=0,
+ },
+ sectionFTPT/.style={
+ every head row/.style={
+ before row={%
+ \toprule
+ },
+ after row=\midrule},
+ every last row/.style={after row=\bottomrule},
+ columns/campus/.style={string type,column name={},column type=l},
+ columns/status/.style={string type,column name={},column type=l},
+ columns/below100/.style={column name={Below 100 level},column type=r},
+ columns/b100percent/.style={column name={\%},percentstyle},
+ columns/above100/.style={column name={Above 100 level},column type=r},
+ columns/a100percent/.style={column name={\%},percentstyle},
+ columns/totpercent/.style={column name={\%},percentstyle},
+ columns/total/.style={column name={Total},column type=r},
+ },
+ demographic/.style={
+ every row no 2/.style={before row=\rowcolor{lightgray!50}},
+ every row no 6/.style={before row=\rowcolor{lightgray!50}},
+ every row no 8/.style={before row=\rowcolor{lightgray!50}},
+ every row no 10/.style={before row=\rowcolor{lightgray!50}},
+ every row no 12/.style={before row=\rowcolor{lightgray!50}},
+ every row no 16/.style={before row=\rowcolor{lightgray!50}},
+ every row no 18/.style={before row=\rowcolor{lightgray!50}},
+ every row no 20/.style={before row=\rowcolor{lightgray!50}},
+ }
+}
+
+% for the section counters for each chapter
+\newcommand{\numbertotext}[1]{%
+ \ifcase#1
+ zero%
+ \or
+ one%
+ \or
+ two%
+ \or
+ three%
+ \or
+ four%
+ \or
+ five%
+ \or
+ six%
+ \else
+ % we don't care about the number of sections in chapters greater than 6
+ unimportant
+ \fi
+}
+
+% empty column type- very useful for big tables that ignore columns
+\newcolumntype{H}{>{\setbox0=\hbox\bgroup}c<{\egroup}@{}}
+
+% centered columns for tabularx in the appendix
+\newcolumntype{Y}{>{\centering\arraybackslash}X}
+
+% right-justified columns for tabularx 
+\newcolumntype{R}{>{\raggedleft\arraybackslash}X}
+
+% glossaries settings- load after hyperref: http://tex.stackexchange.com/questions/1863/which-packages-should-be-loaded-after-hyperref-instead-of-before
+\usepackage[nonumberlist,section=chapter,toc,]{glossaries}
+% use longragged style, based on longtable
+\usepackage{glossary-longragged}
+\setglossarystyle{longragged}
+% widen description column
+\setlength{\glsdescwidth}{0.8\linewidth}
+% make entries bold and black
+\renewcommand{\glsnamefont}[1]{\textbf{#1}}
+\renewcommand*{\glstextformat}[1]{\textcolor{black}{#1}}
+% basic vocab
+\newglossaryentry{ACCEPT}{name=ACCEPT,description={Addressing the Collective Climate and Experience of Part-Timers}}
+\newglossaryentry{ADA}{name=ADA,description={Americans with Disabilities Act}}
+\newglossaryentry{ALC}{name=ALC,description={Alternative Learning Center. A former name for the SLC. Several self-paced courses in Math and English have this subject prefix}}
+\newglossaryentry{ALEKS}{name=ALEKS,description={ {\bfseries A}ssessment and {\bfseries LE}arning in {\bfseries K}nowledge {\bfseries S}paces interactive computer-based math-learning program owned by McGraw-Hill \url{http://www.aleks.com/}}}
+\newglossaryentry{AMP}{name=AMP,description={Accelerated Mathematics Program}}
+\newglossaryentry{AY}{name=AY,description={Academic Year}}
+\newglossaryentry{CIC}{name=CIC,description={Completion Investment Council}}
+\newglossaryentry{CTE}{name=CTE,description={Career Technical Education}}
+\newglossaryentry{OSD}{name=OSD,description={Office of Students with Disabilities}}
+\newglossaryentry{CCOG}{name=CCOG,description={Course Curriculum and Outcome Guide}}
+\newglossaryentry{DL}{name=DL,description={Distance Learning}}
+\newglossaryentry{DOI}{name=DOI,description={Deans Of Instruction}}
+\newglossaryentry{F2F}{name=F2F,description={Face-to-face}}
+\newglossaryentry{FT}{name=FT,description={Full-time (usually in reference to faculty)}}
+\newglossaryentry{LAC}{name=LAC,description={Learning Assessment Council}}
+\newglossaryentry{LAS}{name=LAS,description={Learning Assessment Subcommittee (of the LAC)}}
+\newglossaryentry{LDC}{name=LDC,description={Lower Division Collegiate}}
+\newglossaryentry{MML}{name=MML,description={MyMathLab: a commercial computer-based homework management system owned and distributed by Pearson \url{http://www.pearsonmylabandmastering.com/northamerica/mymathlab/}}}
+\newglossaryentry{MSL}{name=MSL,description={MyStatLab: a commercial computer-based homework management system owned and distributed by Pearson \url{http://www.pearsonmylabandmastering.com/northamerica/mystatlab/}}}
+\newglossaryentry{PT}{name=PT,description={Part-time (usually in reference to faculty)}}
+\newglossaryentry{SAC}{name=SAC,description={Subject Area Committee}}
+\newglossaryentry{SLC}{name=SLC,description={Student Learning Center. An informal, open study area, with the added benefit of tutoring assistance}}
+\newglossaryentry{STEM}{name=STEM,description={Science, Technology, Engineering, and Mathematics}}
+\newglossaryentry{WRC}{name=WRC,description={Women's Resource Center}}
+\makeglossaries
+
+% to do: (bash scripts/logfilecheck.sh)
+%   - address all fixthis issues (check output and .log file) Chris
+%   - check for undefined references, multiply defined labels- grep log file Chris
+%   - check functionality in various browsers, OSs
+
+% Define fix command
+% 	- it puts a comment in the margin
+% 	- it writes to a file with a list of things that need fixing
+\newcommand{\fixthis}[1]
+{%
+ \marginpar{\huge \color{red} \pdftooltip{\framebox{FIX}}{#1}}%
+ \typeout{FIXTHIS: Section \thechapter:  p\thepage : #1^^J}%
+}
+
+% for the section pictures
+\makeatletter
+\newcommand{\cmh}[2]{%
+ % we need the first argument to be a number
+ % http://tex.stackexchange.com/questions/50111/how-to-check-if-the-value-of-a-parameter-is-a-number
+ \if\relax\detokenize\expandafter{\romannumeral-0#1}\relax
+ \@ifundefined{c@totalsections@\numbertotext{#1}}%
+ {%
+ \newcounter{totalsections@\numbertotext{#1}}
+ \setcounter{totalsections@\numbertotext{#1}}{#2}
+ \typeout{Defining a new counter: totalsections@\numbertotext{#1}}
+ }%
+ {%
+ \ifnum\value{totalsections@\numbertotext{#1}}=#2
+ \typeout{Total sections for Chapter #1 match auxilary file (#2)}
+ \else
+ \typeout{Warning: total sections for Chapter #1 updated from \the\value{totalsections@\numbertotext{#1}} to #2-- recompile to fix}
+ \fi
+ \setcounter{totalsections@\numbertotext{#1}}{#2}
+ }%
+ \else
+ \fi
+}
+
+% custom petal shape
+% custom petal shape
+% custom petal shape
+% http://tex.stackexchange.com/questions/151962/rotating-a-custom-shape-independently-of-the-text/151978?noredirect=1#151978
+\pgfkeys{/pgf/shape border rotate/.initial=0}
+
+\pgfdeclareshape{petal}
+{
+ \inheritsavedanchors[from=circle] % this is nearly a circle
+ \inheritanchorborder[from=circle]
+ \inheritanchor[from=circle]{center}
+ \inheritanchor[from=circle]{base}
+ \savedmacro\petalparameters{%
+ \pgfmathsetmacro\shapeborderrotate{\pgfkeysvalueof{/pgf/shape border rotate}}%
+ \addtosavedmacro\shapeborderrotate%
+ }
+ \backgroundpath{
+ % origin
+ \petalparameters%
+ {% Make sure transformations are  inside group.
+ \pgftransformshift{\centerpoint}%
+ \pgftransformrotate{\shapeborderrotate}%
+ \pgfutil@tempdima=\radius%
+ \pgfpathmoveto{\pgfqpoint{\pgfutil@tempdima}{0pt}}%
+ \pgfpatharc{0}{180}{\pgfutil@tempdima}%
+ \pgfpathcurveto{\pgfqpoint{-\pgfutil@tempdima}{-.5\pgfutil@tempdima}}%
+ {\pgfqpoint{-.5\pgfutil@tempdima}{-.75\pgfutil@tempdima}}%
+ {\pgfqpoint{0pt}{-1.5\pgfutil@tempdima}}
+ \pgfpathcurveto{\pgfqpoint{0pt}{-.75\pgfutil@tempdima}}%
+ {\pgfqpoint{\pgfutil@tempdima}{-.75\pgfutil@tempdima}}%
+ {\pgfqpoint{\pgfutil@tempdima}{0pt}}%
+ }%
+ }
+}
+
+% boolean switch to tell if we're in the appendix or not
+\newbool{inappendix}
+
+% make epigraph italic
+\let\oldepigraph\epigraph
+\renewcommand{\epigraph}[2]{\oldepigraph{\itshape #1}{#2}}
+
+% write to the auxilary file before each \chapter command
+\preto\chapter{%
+ \ifnum\value{chapter}>0
+ \immediate\write\@auxout{%
+ \string\cmh\string{\thechapter\string}\string{\the\value{section}\string}
+ }
+ \fi
+ }
+
+% ... and the appendix- the above command won't work because the appendix
+% command resets the chapter counter
+\preto\appendix{%
+ \booltrue{inappendix}
+ \immediate\write\@auxout{%
+ \string\cmh\string{\thechapter\string}\string{\the\value{section}\string}
+ }
+}
+
+% colorbox settings
+\tcbset{
+ pccstyle/.style={
+ % used in chapter headings and toc headings
+ enhanced,flushright upper,
+ boxrule=1.4pt,
+ colback=white,colframe=black!50!yellow,
+ drop fuzzy midday shadow=black!50!yellow
+ },
+ tocstyle/.style={
+ % used to surround the tocs (main and appendix)
+ breakable,enhanced,fonttitle=\bfseries\Large,
+ colback=gray!10,colframe=gray,%colframe=red!50!black,
+ before=\par\bigskip\noindent,
+ pad at break=3mm,
+ %left=0.75cm,
+ %enlargepage=2\baselineskip,
+ drop fuzzy shadow,
+ }
+}
+
+% heading settings
+% heading settings
+% heading settings
+
+% from the titlesec package
+%\titleformat{ command }
+%             [ shape ]
+%             { format }{ label }{ sep }{ before-code }[ after-code ]
+% custom chapter
+\titleformat{\chapter}
+{\normalfont\Large\filleft\bfseries}                    % format applied to label+text
+{}                                                      % label
+{1pc}                                                   % horizontal separation between label and title body
+{%
+ % add heading recommendation file
+ \ifbool{inappendix}{}{%
+ \ifnum\value{chapter}<7
+ \ifnum\value{chapter}>0
+ \addcontentsline{toc}{pcctitle}{Recommendations for section \thechapter}%
+ \fi
+ \fi
+ }%
+ % draw a box around the chapter number
+ \begin{tcolorbox}[pccstyle,width=2.8cm]
+ \resizebox{2cm}{!}{\color{gray!80}\thechapter}%
+ \end{tcolorbox}\Huge} % before the title body
+%\resizebox{2cm}{!}{\color{gray!80}\thechapter}\\\Huge} % before the title body
+[]                                                      % after the title body
+
+% \chapter*
+\titleformat{name=\chapter,numberless}
+{\normalfont\huge\bfseries}{}{-20pt}{\Huge}
+
+% custom section
+\titleformat{\section}
+{%
+ \hypertarget{section:petal:\thechapter:\thesection}%
+ \large\bfseries%
+}
+{%
+ % original line- maybe we'll just use it after all :)
+ %\llap{\vbox to 5pt{\hbox{\resizebox{1cm}{!}{\normalfont\thesection.}}}\hskip 9pt}
+ % new stuff
+ \@ifundefined{c@totalsections@\numbertotext{\thechapter}}%
+ {% if the total number of sections for this chapter is undefined
+ \llap{\vbox to 5pt{\hbox{\resizebox{1cm}{!}{\normalfont\thesection.}}}\hskip 9pt}
+ }%
+ {% if the total number of sections for this chapter is DEFINED
+ %Defined \thechapter: total sections: \thetotalsections@one 
+ \llap{\vbox to 0pt{\vss\hbox{%
+ \begin{tikzpicture}[
+ scale=0.8,
+ every node/.style={draw,
+ petal,
+ double,
+ minimum width=0.5cm,
+ shape border rotate=-(\i-1)*360/\mymax,
+ }]
+ \def\mymax{\the\value{totalsections@\numbertotext{\thechapter}}}
+ % define the radius dependent on the total petals
+ \ifnum\mymax=6
+ \def\myradius{1.0cm}
+ \else
+ \def\myradius{0.9cm}
+ \fi
+ \foreach \i in {1,2,...,\mymax}
+ {
+ \pgfmathparse{90-(\i-1)*360/\mymax}
+ \ifnum\i=\the\value{section}
+ \node[fill=red!70] at (\pgfmathresult:\myradius)  {\bfseries\@Alph{\i}};
+ \else
+ \node[draw=gray!50,fill=gray!50] at (\pgfmathresult:\myradius)  {\hypersetup{linkcolor=gray}\hyperlink{section:petal:\thechapter:\@Alph{\i}}{\@Alph{\i}}};
+ \fi
+ }
+ \end{tikzpicture}%
+ \hskip 9pt
+ }%
+ \vss%
+ }%
+ }%
+ }%
+}
+{0pt}
+{}
+
+% custom paragraph heading
+\titleformat{\paragraph}[leftmargin]
+{\normalfont
+ \scshape\filleft}
+{}
+{0pt}
+{}
+
+% spacing around headings
+% From the titlesec package
+% \titlespacing{command}{left spacing}{before spacing}{after spacing}[right]
+% spacing: how to read {12pt plus 4pt minus 2pt}
+%           12pt is what we would like the spacing to be
+%           plus 4pt means that TeX can stretch it by at most 4pt
+%           minus 2pt means that TeX can shrink it by at most 2pt
+%       This is one example of the concept of, 'glue', in TeX
+\titlespacing{\chapter}{0pt}{0pt}{0.1cm}
+\titlespacing\section{0pt}{12pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing\subsection{0pt}{12pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing\subsubsection{0pt}{-3pt plus 4pt minus 2pt}{-6pt plus 2pt minus 2pt}
+\titlespacing{\paragraph}{4pc}{1.5ex plus .1ex minus .2ex}{1pc}
+
+% secnumdepth dictates which headings get enumerated- setting it 
+% to 1 means that chapters and sections get enumerated, but 
+% no headings below them will (such as subsection, subsubsection, paragraph, etc)
+\setcounter{secnumdepth}{1}
+
+% toc settings
+% toc settings
+% toc settings
+%
+% \titlecontents{<heading>}
+%   [] % left margin
+%   {} % before code
+%   {} % formatting for numbered entries of this type
+%   {} % formatting for UNnumbered entries of this type
+%   {} % filler page format
+\titlecontents{chapter}%
+[0pc]       % left margin
+{\vspace{.5cm}}
+{%          % numbered format
+ \llap{\vbox to 10pt{%
+ \hbox{%
+ %    \resizebox{1cm}{!}{\color{gray}\thecontentslabel}\hskip 0.5cm
+ \begin{tcolorbox}[pccstyle,width=1.8cm]
+ \resizebox{1cm}{!}{\color{gray}\thecontentslabel}\hskip 1.5cm
+ \end{tcolorbox}
+ }%
+ }%
+ }\color{blue!40}\large\sc\bfseries%
+}
+{\large\sc}          % unnumbered format
+{\titlerule*[.5pc]{.}\large\sc Page \bfseries\contentspage}%
+
+% indented subsection (in toc)
+\titlecontents{subsection}
+[2.0cm]             % left margin
+{}                  % above code
+{%                  % numbered format
+ {\thecontentslabel\hskip .5cm}%
+}%
+{}         % unnumbered format
+{\titlerule*[.5pc]{.}\contentspage}%
+
+% headers and footers
+\fancyhf{} % delete current header and footer
+\fancyhead[LE,RO]{\bfseries\thepage}
+\fancyhead[LO,RE]{\leftmark}
+\fancyheadoffset[LE,LO]{3cm}
+\pagestyle{fancy}
+
+% remove the word Chapter from the header
+\def\chaptermark#1{\markboth{\textsc{\thechapter. \  #1}}{}}
+
+%%%%% make refcheck and cleveref play nicely together (not needed once the document is complete): 
+%%% http://tex.stackexchange.com/questions/87610/making-refcheck-work-with-cleveref
+%%\makeatletter
+%%\newcommand{\refcheckize}[1]{%
+%%\expandafter\let\csname @@\string#1\endcsname#1%
+%%\expandafter\DeclareRobustCommand\csname relax\string#1\endcsname[1]{%
+%%\csname @@\string#1\endcsname{##1}\wrtusdrf{##1}}%
+%%\expandafter\let\expandafter#1\csname relax\string#1\endcsname
+%%}
+%%% Now we add the reference commands we want refcheck to be aware of
+%%\refcheckize{\vref}
+%%\refcheckize{\cref}
+%%\refcheckize{\Cref}
+%%\refcheckize{\cpageref}
+%%%%%
+
+% wide page for side by side figures, tables, etc
+\newlength{\offsetpage}
+\setlength{\offsetpage}{3.0cm}
+\newenvironment{widepage}{\begin{adjustwidth}{-\offsetpage}{}%{-.5\offsetpage}%
+ \addtolength{\textwidth}{2\offsetpage}}%
+ {\end{adjustwidth}}
+
+% renew the quote environment to make it italic
+\let\oldquote\quote
+\let\oldendquote\endquote
+\renewenvironment{quote}{\oldquote \itshape}{\oldendquote}
+
+% for quotations with an attributed source
+\def\signed #1{{\leavevmode\unskip\nobreak\hfil\penalty50\hskip2em
+ \hbox{}\nobreak\hfil#1%
+ \parfillskip=0pt \finalhyphendemerits=0 \endgraf}}
+
+\newsavebox\mybox
+\newenvironment{aquote}[1]
+{\savebox\mybox{#1}\begin{quote}}
+ {\signed{\usebox\mybox}\end{quote}}
+
+% recommendations
+% recommendations
+% recommendations
+
+% this creates a 'dummy' heading level after paragraph, which we can exploit
+% to read in the recommendations from the toc
+\titleclass{\pcctitle}{straight}[\paragraph]
+\titleformat{\pcctitle}{}{}{}{}
+\titlecontents{pcctitle}
+[3.8cm]             % left margin
+{}                  % above code
+{% numbered format
+ \raisebox{0pt}[0pt][0pt]{\llap{\begin{minipage}[t]{6cm}
+ \bfseries\raggedleft\thecontentslabel\end{minipage}~~}}%
+}%                  
+{\scshape\hypersetup{linkcolor=black}}         % unnumbered format
+{\titlerule*[.5pc]{.}\contentspage}%
+
+% need to set the toclevel here, otherwise the recommendations appear in bookmarks
+% http://tex.stackexchange.com/questions/123575/how-to-suppress-the-author-bookmark-generated-by-svmult-with-bookmark-package-wi
+\makeatletter
+\providecommand*{\toclevel@pcctitle}{7}
+
+% command to output recommendation on the page, and also add it
+% to the list of recommendations
+\newcommand{\recommendation}[2][]{%
+ \raisebox{0pt}[0pt][0pt]{\llap{%
+ \tikz[baseline=(X.base)] \node[star,fill=yellow,draw=orange,scale=0.65] (X){R};\hskip .5cm%
+ }}%
+ \phantomsection
+ #2%
+ \ifx\\#1\\% if the first argument is empty then use the second (default)
+ \addcontentsline{toc}{pcctitle}{#2}%
+ \else % if we want to put something else in the list of recommendations
+ \addcontentsline{toc}{pcctitle}{\protect\numberline{\protect#1} #2}%
+ \fi%
+}
+
+%\includeonly{Overview}
+%\includeonly{OutcomesAndAssessment,appendices/coreOutcomesMapping}
+%\includeonly{OtherCurricularIssues}
+%\includeonly{NeedsOfStudentsAndCommunity}
+%\includeonly{FacultyReflection}
+%\includeonly{FacilitiesAndSupport}
+%\includeonly{appendices/dlSuccessfulCompletion}
+%\includeonly{Recommendations}
+%\includeonly{colophon}
+%\includeonly{appendices/enrollmentSummaries}
+%\includeonly{appendices/tutoringHours}
+%\includeonly{colophon}
+%\includeonly{appendices/pathways}
+%\includeonly{appendices/professionalDevelopment}
+
+% special characters in url in footnote: http://tex.stackexchange.com/questions/12230/getting-percent-sign-into-an-url-in-a-footnote
+\urldef\awardsurl\url{http://www.pcc.edu/resources/academic/learning-assessment/sac-resources.html#assessmentwin}
+
+\begin{document}
+
+% add a bookmark for the toc
+\pdfbookmark{Title page}{Title Page}
+
+% title page
+\includepdf{graphics/titlePage}
+
+% add a bookmark for the toc
+\pdfbookmark{\contentsname}{Contents}
+
+% this bit puts a tcolorbox around the toc
+\begin{tcolorbox}[tocstyle,
+ title={Contents},
+ %watermark text={\bfseries\Large Contents},
+ %watermark color=yellow!75!red!25!white,
+ ]
+ \makeatletter
+ \@starttoc{toc}
+ \makeatother
+\end{tcolorbox}
+
+\glsaddall
+\printglossary
+
+% needed for the recommendation toc
+\startcontents
+
+%= == == == == == == == == == == =
+% main chapters
+%= == == == == == == == == == == =
+\renewcommand{\thesection}{\Alph{section}}
+\include{Overview}
+\include{OutcomesAndAssessment}
+\include{OtherCurricularIssues}
+\include{NeedsOfStudentsAndCommunity}
+\include{FacultyReflection}
+\include{FacilitiesAndSupport}
+% I don't like doing this, but there is no chapter 7
+\makeatletter
+\immediate\write\@auxout{%
+ \string\cmh\string{\thechapter\string}\string{\the\value{section}\string}
+}
+\makeatother
+\refstepcounter{chapter}
+\include{Recommendations}
+
+%= == == == == == == == == == == =
+% bibliography
+% bibliography
+% bibliography
+%= == == == == == == == == == == =
+\setcounter{biburllcpenalty}{100}
+\printbibliography[heading=bibintoc]
+
+%= == == == == == == == == == == =
+% appendices
+% appendices
+% appendices
+%= == == == == == == == == == == =
+\appendix
+% add the word Appendix to the header
+\def\chaptermark#1{\markboth{\textsc{Appendix \thechapter. \  #1}}{}}
+% custom section
+\titleformat{\section}
+{\Large\bfseries}
+{\llap{\thesection\hskip.5cm}}
+{0pt}
+{}
+\titlespacing\section{0pt}{12pt plus 4pt minus 2pt}{-5pt plus 2pt minus 2pt}
+
+% need to change the chapter formatting for the appendices
+\titlecontents{chapter}
+[0pc]             % left margin
+{\vskip.25cm}    % above code
+{%                  % numbered format
+ {\hskip.5cm\color{black}\large\thecontentslabel\hskip .2cm}\large\sc%
+}%
+{\large\sc}         % unnumbered format
+{\titlerule*[.5pc]{.}\large\sc\bfseries \contentspage}%
+
+% need to change the section formatting for the appendices
+\titlecontents{section}
+[1cm]               % left margin
+{}                  % above code
+{%                  % numbered format
+ {\thecontentslabel\hskip .5cm}%
+}%
+{}         % unnumbered format
+{\titlerule*[.5pc]{.}\contentspage}%
+
+\titlecontents{subsection}
+[1.7cm]               % left margin
+{}                  % above code
+{%                  % numbered format
+ {\thecontentslabel\hskip .5cm}%
+}%
+{}         % unnumbered format
+{\titlerule*[.5pc]{.}\contentspage}%
+
+\renewcommand{\thesection}{\arabic{section}}
+% start a partial tableofcontents for the appendix
+\clearpage
+\thispagestyle{plain}
+\phantomsection
+\addcontentsline{toc}{chapter}{Appendices}
+\startcontents[appendixtoc]
+\begin{tcolorbox}[tocstyle,title={Appendices}]
+ \printcontents[appendixtoc]{}{0}{}
+\end{tcolorbox}
+\include{appendices/pathways}
+\include{appendices/changeinALCcourses}
+\include{appendices/socialJustice}
+\include{appendices/coreOutcomesMapping}
+\include{appendices/dlSuccessfulCompletion}
+\include{appendices/demographicData}
+\include{appendices/onlineHwStudy}
+\include{appendices/ALEKSpilot}
+\include{appendices/ampData}
+\include{appendices/effectivenessALC}
+\include{appendices/enrollmentSummaries}
+\include{appendices/classSize}
+\include{appendices/accessibilitysummary}
+\include{appendices/sectionsTaughtPTFT}
+\include{appendices/facultyDegrees}
+\include{appendices/instructorQualifications}
+\include{appendices/memberships}
+\include{appendices/professionalDevelopment}
+\include{appendices/resourcesurvey}
+\include{appendices/tutoringHours}
+\include{appendices/courseScheduling}
+
+%= == == == == == == == == == == =
+% colophon
+% colophon
+% colophon
+%= == == == == == == == == == == =
+\pdfbookmark{Colophon}{Colophon}
+\include{colophon}
+
+\end{document}
+

--- a/test-cases/texexchange/texexchange-test-cases.sh
+++ b/test-cases/texexchange/texexchange-test-cases.sh
@@ -170,7 +170,8 @@ latexindent.pl -s 141087.tex -o=141087-out.tex -l=pgfplotstableread.yaml
 # =======  not from tex exchange, but seemed appropriate here  =========
 # =======  not from tex exchange, but seemed appropriate here  =========
 # =======  not from tex exchange, but seemed appropriate here  =========
-latexindent.pl -s pcc-pr.tex -o=pcc-pr-default.tex -l indentPreamble.yaml
+latexindent.pl -s pcc-pr.tex -o=+-default.tex -l indentPreamble.yaml
 latexindent.pl -s pcc-pr-presentation.tex -o=pcc-pr-presentation-default.tex -l indentPreamble.yaml
+latexindent.pl -s pcc-pr.tex -o=+-max-indentation -l indentPreamble.yaml,../environments/max-indentation1.yaml
 [[ $noisyMode == 1 ]] && makenoise
 git status


### PR DESCRIPTION
This pull request implements `maximumIndentation` to be specified as horizontal space; it addresses https://github.com/cmhughes/latexindent.pl/issues/50

It uses the `Text::Tabs` module; when used *any* leading tabs will be replaced with spaces. This is documented in the documentation.

`maximumIndentation` is off by default, and will only be used if it is specified as horizontal white space.