### PR TITLE
always output log/help text to STDERR

### DIFF
--- a/LatexIndent/LogFile.pm
+++ b/LatexIndent/LogFile.pm
@@ -140,7 +140,7 @@ ENDQUOTE
     if($switches{screenlog}){
         $appender_screen = Log::Log4perl::Appender->new(
             "Log::Log4perl::Appender::Screen",
-            stderr => 0,
+            stderr => 1,
             utf8   => 1,
         );
 
@@ -160,7 +160,7 @@ ENDQUOTE
     } else {
         $logger->info("Reading input from STDIN");
         my $buttonText = ($FindBin::Script eq 'latexindent.exe') ? 'CTRL+Z followed by ENTER':'CTRL+D';
-        print "Please enter text to be indented: (press $buttonText when finished)\n";
+        print STDERR "Please enter text to be indented: (press $buttonText when finished)\n";
     }
 
     # log the switches from the user


### PR DESCRIPTION
The formatting tool in the most editors works in the following way:
* It pipes the current buffer to the formatting tool using STDIN.
* It captures the output of the STDOUT and replace the editor buffer with them.

Therefore, it is important that log and help text should not output to STDOUT.

Fixes #120