### PR TITLE
Print usage tip to STDERR only if STDIN is TTY

### DIFF
--- a/LatexIndent/LogFile.pm
+++ b/LatexIndent/LogFile.pm
@@ -168,8 +168,10 @@ ENDQUOTE
         $logger->info("Filename: ${$self}{fileName}");
     } else {
         $logger->info("Reading input from STDIN");
-        my $buttonText = ($FindBin::Script eq 'latexindent.exe') ? 'CTRL+Z followed by ENTER':'CTRL+D';
-        print STDERR "Please enter text to be indented: (press $buttonText when finished)\n";
+        if (-t STDIN) {
+            my $buttonText = ($FindBin::Script eq 'latexindent.exe') ? 'CTRL+Z followed by ENTER':'CTRL+D';
+            print STDERR "Please enter text to be indented: (press $buttonText when finished)\n";
+        }
     }
 
     # log the switches from the user


### PR DESCRIPTION
To keep the STDERR clean for automated tools.

A quick fix to print the usage tip:
```
Please enter text to be indented: (press CTRL+D when finished)
```
only if terminal is interactive.