### PR TITLE
Add STDIN testcase to appveyor-test-cases.bat

### DIFF
--- a/test-cases/continuous-integration/appveyor-test-cases.bat
+++ b/test-cases/continuous-integration/appveyor-test-cases.bat
@@ -14,3 +14,5 @@ echo "----------4. localSettings and modify line breaks--------------\n"
 perl latexindent.pl -l -m environments-nested-fourth
 echo "----------5. localSettings renamed and modify line breaks--------------\n"
 perl latexindent.pl -l=env-all-on -m environments-nested-fourth
+echo "----------6. STDIN/cat mode--------------\n"
+perl latexindent.pl < environments-nested-fourth.tex


### PR DESCRIPTION
With #174, I noticed the Appveyor CI script was missing STDIN functional test outputs compared to [Travis-CI](https://github.com/sransara/latexindent.pl/blob/470f27def7a7d6a0a0dd98ebde9176f6eee902c3/test-cases/continuous-integration/test-travis-ci.sh#L16). This pull request should include the missing case.