### PR TITLE
Search localSettings in CWD as well

### DIFF
--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -20,6 +20,7 @@ use LatexIndent::Switches qw/%switches $is_m_switch_active $is_t_switch_active $
 use YAML::Tiny;                # interpret defaultSettings.yaml and other potential settings files
 use File::Basename;            # to get the filename and directory path
 use File::HomeDir;
+use Cwd;
 use Log::Log4perl qw(get_logger :levels);
 use Exporter qw/import/;
 our @EXPORT_OK = qw/yaml_read_settings yaml_modify_line_breaks_settings yaml_get_indentation_settings_for_this_object yaml_poly_switch_get_every_or_custom_value yaml_get_indentation_information yaml_get_object_attribute_for_indentation_settings yaml_alignment_at_ampersand_settings yaml_get_textwrap_removeparagraphline_breaks %masterSettings yaml_get_columns/;
@@ -169,6 +170,7 @@ sub yaml_read_settings{
     push(@localSettings,$switches{readLocalSettings}) if($switches{readLocalSettings});
   }
 
+  my $workingFileLocation = dirname (${$self}{fileName});
   # add local settings to the paths, if appropriate
   foreach (@localSettings) {
     # check for an extension (.yaml)
@@ -180,8 +182,14 @@ sub yaml_read_settings{
     # if the -l switch is called on its own, or else with +
     # and latexindent.pl is called from a different directory, then
     # we need to account for this
-    if($_ eq "localSettings.yaml"){
-        $_ = dirname (${$self}{fileName})."/".$_;
+    if($_ eq "localSettings.yaml" ){
+        # check for existence in the directory of the file.
+        if ( (-e $workingFileLocation."/".$_) ) {
+            $_ = $workingFileLocation."/".$_;
+        # otherwise we fallback to the current directory
+    	} elsif( (-e cwd()."/".$_) ){
+            $_ = cwd()."/".$_;
+        }
     }
 
     # check for existence and non-emptiness

--- a/LatexIndent/LogFile.pm
+++ b/LatexIndent/LogFile.pm
@@ -62,8 +62,9 @@ usage: latexindent.pl [options] [file][.tex|.sty|.cls|.bib|...]
       -t, --trace
           tracing mode: verbose information given to the log file
       -l, --local[=myyaml.yaml]
-          use localSettings.yaml (assuming it exists in the directory of your file);
-          alternatively, use myyaml.yaml, if it exists; sample usage:
+          use localSettings.yaml (assuming it exists in the directory of your file, 
+          or in the current working directory); alternatively, use myyaml.yaml, if it exists; 
+          sample usage:
                 latexindent.pl -l some.yaml myfile.tex 
                 latexindent.pl -l=another.yaml myfile.tex 
                 latexindent.pl -l=some.yaml,another.yaml myfile.tex 

--- a/documentation/sec-how-to-use.rst
+++ b/documentation/sec-how-to-use.rst
@@ -240,10 +240,11 @@ script will be affected).
 
 ``latexindent.pl`` will always load ``defaultSettings.yaml`` (rhymes
 with camel) and if it is called with the ``-l`` switch and it finds
-``localSettings.yaml`` in the same directory as ``myfile.tex`` then
-these settings will be added to the indentation scheme. Information will
-be given in ``indent.log`` on the success or failure of loading
-``localSettings.yaml``.
+``localSettings.yaml`` in the same directory as ``myfile.tex``, then, 
+if not found, it looks for ``localSettings.yaml`` in the current working 
+directory, then these settings will be added to the indentation scheme. 
+Information will be given in ``indent.log`` on the success or failure of
+loading ``localSettings.yaml``.
 
 The ``-l`` flag can take an *optional* parameter which details the name
 (or names separated by commas) of a YAML file(s) that resides in the

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -195,7 +195,8 @@ latexindent.pl myfile.tex -l=first.yaml,second.yaml,third.yaml
 	\label{page:localswitch}
 	\texttt{latexindent.pl} will always load \texttt{defaultSettings.yaml} (rhymes with camel)
 	and if it is called with the \texttt{-l} switch and it finds
-	\texttt{localSettings.yaml} in the same directory as \texttt{myfile.tex} then these
+	\texttt{localSettings.yaml} in the same directory as \texttt{myfile.tex}, then, if not found, 
+	it looks for \texttt{localSettings.yaml} in the current working directory, then these
 	settings will be added to the indentation scheme. Information will be given in
 	\texttt{indent.log} on the success or failure of loading \texttt{localSettings.yaml}.
 

--- a/test-cases/continuous-integration/appveyor-test-cases.bat
+++ b/test-cases/continuous-integration/appveyor-test-cases.bat
@@ -3,6 +3,8 @@ echo "again again"
 cp ../environments/environments-nested-fourth.tex ../../
 cp ../environments/env-all-on.yaml ../../localSettings.yaml
 cp ../environments/env-all-on.yaml ../../env-all-on.yaml
+mkdir ../../localSettingsTest
+cp ../environments/environments-nested-fourth.tex ../../localSettingsTest/
 cd ../../
 echo "----------1. basic test--------------\n"
 perl latexindent.pl environments-nested-fourth.tex
@@ -12,7 +14,9 @@ echo "----------3. overwrite--------------\n"
 perl latexindent.pl -w environments-nested-fourth.tex
 echo "----------4. localSettings and modify line breaks--------------\n"
 perl latexindent.pl -l -m environments-nested-fourth
-echo "----------5. localSettings renamed and modify line breaks--------------\n"
+echo "----------5. localSettings in CWD--------------\n"
+perl latexindent.pl -l -m localSettingsTest/environments-nested-fourth
+echo "----------6. localSettings renamed and modify line breaks--------------\n"
 perl latexindent.pl -l=env-all-on -m environments-nested-fourth
-echo "----------6. STDIN/cat mode--------------\n"
+echo "----------7. STDIN/cat mode--------------\n"
 perl latexindent.pl < environments-nested-fourth.tex

--- a/test-cases/continuous-integration/test-travis-ci.sh
+++ b/test-cases/continuous-integration/test-travis-ci.sh
@@ -2,6 +2,8 @@
 cp ../environments/environments-nested-fourth.tex ../../
 cp ../environments/env-all-on.yaml ../../localSettings.yaml
 cp ../environments/env-all-on.yaml ../../env-all-on.yaml
+mkdir ../../localSettingsTest
+cp ../environments/environments-nested-fourth.tex ../../localSettingsTest/
 cd ../../
 echo "----------1. basic test--------------\n"
 perl latexindent.pl environments-nested-fourth.tex
@@ -11,8 +13,10 @@ echo "----------3. overwrite--------------\n"
 perl latexindent.pl -w environments-nested-fourth.tex
 echo "----------4. localSettings and modify line breaks--------------\n"
 perl latexindent.pl -l -m environments-nested-fourth
-echo "----------5. localSettings renamed and modify line breaks--------------\n"
+echo "----------5. localSettings in CWD--------------\n"
+perl latexindent.pl -l -m localSettingsTest/environments-nested-fourth
+echo "----------6. localSettings renamed and modify line breaks--------------\n"
 perl latexindent.pl -l=env-all-on -m environments-nested-fourth
-echo "----------6. STDIN/cat mode--------------\n"
+echo "----------7. STDIN/cat mode--------------\n"
 cat environments-nested-fourth.tex|perl latexindent.pl
 exit

--- a/test-cases/documentation/sec-how-to-use-mod1.tex
+++ b/test-cases/documentation/sec-how-to-use-mod1.tex
@@ -140,10 +140,10 @@ latexindent.pl myfile.tex -l=first.yaml,second.yaml,third.yaml
       \end{commandshell}
 
 	\label{page:localswitch}
-	\texttt{latexindent.pl} will always load \texttt{defaultSettings.yaml} (rhymes with camel) and if it is called with the \texttt{-l} switch and it finds \texttt{localSettings.yaml} in the same directory as \texttt{myfile.tex} then these settings will be added to the indentation scheme.
+	\texttt{latexindent.pl} will always load \texttt{defaultSettings.yaml} (rhymes with camel) and if it is called with the \texttt{-l} switch and it finds \texttt{localSettings.yaml} in the same directory as \texttt{myfile.tex}, then, if not found, looks in the current working directory, then these settings will be added to the indentation scheme.
 	Information will be given in \texttt{indent.log} on the success or failure of loading \texttt{localSettings.yaml}.
 
-	The \texttt{-l} flag can take an \emph{optional} parameter which details the name (or names separated by commas) of a YAML file(s) that resides in the same directory as \texttt{myfile.tex}; you can use this option if you would like to load a settings file in the current working directory that is \emph{not} called \texttt{localSettings.yaml}.
+	The \texttt{-l} flag can take an \emph{optional} parameter which details the name (or names separated by commas) of a YAML file(s) that resides in the same directory as \texttt{myfile.tex}, then, if not found, in the current working directory; you can use this option if you would like to load a settings file in the current working directory that is \emph{not} called \texttt{localSettings.yaml}.
 	\announce{2017-08-21}*{-l switch absolute paths}
 	In fact, you can specify both \emph{relative} and \emph{absolute paths} for your YAML files; for example \begin{commandshell}
 latexindent.pl -l=../../myyaml.yaml myfile.tex


### PR DESCRIPTION
This commit adds the ability to also search for localSettings.yaml in CWD if it was not found in the path of the working file.