### PR TITLE
Regex::Grammars pair environment name in begin and end statements

### DIFF
--- a/LatexIndent/AlignmentAtAmpersand.pm
+++ b/LatexIndent/AlignmentAtAmpersand.pm
@@ -61,23 +61,22 @@ sub find_aligned_block{
                                 (?!<\\)
                                 %
                                 \*
-                                \h*                     # possible horizontal spaces
+                                \h*                       # possible horizontal spaces
                                 \\begin\{
-                                        $alignmentBlock  # environment name captured into $2
-                                       \}               # %* \begin{alignmentBlock} statement
+                                        ($alignmentBlock) # environment name captured into $2
+                                       \}                 # \begin{alignmentBlock} statement captured into $1
                             )
                             (
-                                .*?
+                                .*?                       # non-greedy match (body) into $3
                             )
-                            \R
-                            \h*
+                            \R                            # a line break
+                            \h*                           # possible horizontal spaces
                             (
                                 (?!<\\)
-                                %\*                     # %
-                                \h*                     # possible horizontal spaces
-                                \\end\{$alignmentBlock\} # \end{alignmentBlock}
-                            )                           # %* \end{<something>} statement
-                            #\R
+                                %\*                       # %
+                                \h*                       # possible horizontal spaces
+                                \\end\{\2\}               # \end{alignmentBlock} statement captured into $4
+                            )
                         /sx;
 
             while( ${$self}{body} =~ m/$alignmentRegExp/sx){
@@ -87,9 +86,9 @@ sub find_aligned_block{
                                 /
                                     # create a new Environment object
                                     my $alignmentBlockObj = LatexIndent::AlignmentAtAmpersand->new( begin=>$1,
-                                                                          body=>$2,
-                                                                          end=>$3,
-                                                                          name=>$alignmentBlock,
+                                                                          body=>$3,
+                                                                          end=>$4,
+                                                                          name=>$2,
                                                                           modifyLineBreaksYamlName=>"environments",
                                                                           linebreaksAtEnd=>{
                                                                             begin=>1,
@@ -99,7 +98,7 @@ sub find_aligned_block{
                                                                           );
             
                                     # log file output
-                                    $logger->trace("*Alignment block found: %*\\begin\{$alignmentBlock\}") if $is_t_switch_active;
+                                    $logger->trace("*Alignment block found: %*\\begin\{${$alignmentBlock}{name}\}") if $is_t_switch_active;
 
                                     # the settings and storage of most objects has a lot in common
                                     $self->get_settings_and_store_new_object($alignmentBlockObj);

--- a/LatexIndent/FileContents.pm
+++ b/LatexIndent/FileContents.pm
@@ -60,30 +60,30 @@ sub find_file_contents_environments_and_preamble{
         my $fileContentsRegExp = qr/
                         (
                         \\begin\{
-                                $fileContentsEnv       
-                               \}                     
+                                ($fileContentsEnv) # environment name captured into $2
+                               \}                  # begin statement captured into $1
                         )
                         (
-                            .*?
+                            .*?                    # non-greedy match (body) into $3
                         )                            
                         (
-                            \\end\{$fileContentsEnv\}  
-                            \h*
+                        \\end\{\2\}                # end statement captured into $4
+                        \h*                        # possible horizontal spaces
                         )                    
-                        (\R)?  
+                        (\R)?                      # possibly followed by a line break
                     /sx;
 
         while( ${$self}{body} =~ m/$fileContentsRegExp/sx){
 
           # create a new Environment object
           my $fileContentsBlock = LatexIndent::FileContents->new( begin=>$1,
-                                                body=>$2,
-                                                end=>$3,
-                                                name=>$fileContentsEnv,
+                                                body=>$3,
+                                                end=>$4,
+                                                name=>$2,
                                                 linebreaksAtEnd=>{
                                                   begin=>0,
                                                   body=>0,
-                                                  end=>$4?1:0,
+                                                  end=>$5?1:0,
                                                 },
                                                 modifyLineBreaksYamlName=>"filecontents",
                                                 );
@@ -112,7 +112,7 @@ sub find_file_contents_environments_and_preamble{
           push(@fileContentsStorageArray,$fileContentsBlock);
 
           # log file output
-          $logger->trace("FILECONTENTS environment found: $fileContentsEnv")if $is_t_switch_active;
+          $logger->trace("FILECONTENTS environment found: ${$fileContentsEnv}{name}")if $is_t_switch_active;
 
           # remove the environment block, and replace with unique ID
           ${$self}{body} =~ s/$fileContentsRegExp/${$fileContentsBlock}{replacementText}/sx;


### PR DESCRIPTION
Update regex expressions to force paired `\begin{name} ... \end{name}` statements. See https://github.com/cmhughes/latexindent.pl/issues/288#issuecomment-925701506 for more details.