### PR TITLE
Regex::Grammars support regex-based verbatim environment and command

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -107,11 +107,17 @@ verbatimEnvironments:
     verbatim: 1
     lstlisting: 1
     minted: 1
+    nameAsRegex:
+      name: '\w+code\*?'  # allows followed by 'code', optionally followed by *
+      lookForThis: 0
 
 #  verbatim commands such as \verb! body !, \lstinline$something else$
 verbatimCommands:
     verb: 1
     lstinline: 1
+    nameAsRegex:
+      name: '\w+inline'  # allows followed by 'inline'
+      lookForThis: 0
 
 #  no indent blocks (not necessarily verbatim 
 #  environments) which are marked as %\begin{noindent}

--- a/test-cases/verbatim/nameAsRegex.yaml
+++ b/test-cases/verbatim/nameAsRegex.yaml
@@ -1,0 +1,12 @@
+noIndentBlock:
+    nameAsRegex:
+      name: '\w+noindent\*?'
+      lookForThis: 1
+
+verbatimEnvironments:
+    nameAsRegex:
+      lookForThis: 1
+
+verbatimCommands:
+    nameAsRegex:
+      lookForThis: 1

--- a/test-cases/verbatim/verbatim-commands.tex
+++ b/test-cases/verbatim/verbatim-commands.tex
@@ -25,3 +25,7 @@ here is some more \lstinline[opt arg]    !body body!
 here is some more \lstinline[ \[x^2\]opt arg]    !body body!
 
 here is some more \lstinline[ ! something !\[x^2\]opt arg]    !body body!
+
+here is some more \pythoninline    |print('Hello, world!')|
+
+here is some more \pythoninline[opt arg]    |print('Hello, world!')|

--- a/test-cases/verbatim/verbatim-test-cases.sh
+++ b/test-cases/verbatim/verbatim-test-cases.sh
@@ -50,6 +50,8 @@ done
 [[ $silentMode == 0 ]] && set -x 
 
 latexindent.pl -s  -m verbatim6 -l=verb-env-1-named.yaml -o=+-mod-1
+latexindent.pl -s  -m verbatim7 -o=+-mod-1-default
+latexindent.pl -s  -m verbatim7 -l=nameAsRegex.yaml -o=+-mod-1
 
 # checking a named version of polyswitch
 latexindent.pl -s  -m verbatim5 -l=verb-env-1-named.yaml -o=+-mod-1-named
@@ -60,7 +62,7 @@ latexindent.pl -s  -m verbatim-special3 -l=verb-special.yaml,verb-spec2-named.ya
 latexindent.pl -s  -m verbatim-trailing-comments -l=verb-begin2.yaml -o=+-mod2
 
 # verbatim command
-latexindent.pl -s -w verbatim-commands.tex
+latexindent.pl -s -w verbatim-commands.tex -l=nameAsRegex.yaml
 latexindent.pl -s verbatim-trailing-comments1.tex -o=+-default
 
 #   verbatim noindent block 

--- a/test-cases/verbatim/verbatim7-mod-1-default.tex
+++ b/test-cases/verbatim/verbatim7-mod-1-default.tex
@@ -1,0 +1,33 @@
+\begin{surround}
+	before text \begin{testnoindent}
+		body text
+		body text
+		body text
+	\end{testnoindent} after text
+
+	before text \begin{testnoindent*}
+		body text
+		body text
+		body text
+	\end{testnoindent*} after text
+
+	before text \begin{latexcode}
+		body text
+		body text
+		body text \begin{pythoncode}
+			for i in range(10):
+			print("Hello, world!")
+		\end{pythoncode} body text
+		body text
+	\end{latexcode} after text
+
+	before text \begin{latexcode*}{linenos=true}
+		body text
+		body text
+		body text \begin{pythoncode}
+			for i in range(10):
+			print("Hello, world!")
+		\end{pythoncode} body text
+		body text
+	\end{latexcode*} after text
+\end{surround}

--- a/test-cases/verbatim/verbatim7-mod-1.tex
+++ b/test-cases/verbatim/verbatim7-mod-1.tex
@@ -1,0 +1,33 @@
+\begin{surround}
+	before text \begin{testnoindent}
+    body text
+      body text
+body text
+\end{testnoindent} after text
+
+	before text \begin{testnoindent*}
+  body text
+    body text
+body text
+\end{testnoindent*} after text
+
+	before text \begin{latexcode}
+    body text
+      body text
+        body text \begin{pythoncode}
+            for i in range(10):
+                print("Hello, world!")
+        \end{pythoncode} body text
+body text
+\end{latexcode} after text
+
+	before text \begin{latexcode*}{linenos=true}
+  body text
+    body text
+      body text \begin{pythoncode}
+          for i in range(10):
+              print("Hello, world!")
+      \end{pythoncode} body text
+body text
+\end{latexcode*} after text
+\end{surround}

--- a/test-cases/verbatim/verbatim7.tex
+++ b/test-cases/verbatim/verbatim7.tex
@@ -1,0 +1,33 @@
+\begin{surround}
+before text \begin{testnoindent}
+    body text
+      body text
+body text
+\end{testnoindent} after text
+
+before text \begin{testnoindent*}
+  body text
+    body text
+body text
+\end{testnoindent*} after text
+
+before text \begin{latexcode}
+    body text
+      body text
+        body text \begin{pythoncode}
+            for i in range(10):
+                print("Hello, world!")
+        \end{pythoncode} body text
+body text
+\end{latexcode} after text
+
+before text \begin{latexcode*}{linenos=true}
+  body text
+    body text
+      body text \begin{pythoncode}
+          for i in range(10):
+              print("Hello, world!")
+      \end{pythoncode} body text
+body text
+\end{latexcode*} after text
+\end{surround}


### PR DESCRIPTION
The first commit:

Add new grammar in settings, new entry `name` (and `lookForThis`) for `noIndentBlock`, `verbatimEnvironments` and `verbatimCommands`:

1. `name` for `noIndentBlock`:
    Set `begin` and `end` to `\\begin\{(${name})\}` and `\\end\{\2\}` when not provided. The group `\2` will force paired name (useful for regex-based envname, no effect for literal) for the environment. The original implementation cannot set `\2` in `end` because users do not know the exact regex group number and it should be set internally.

2. `name` for `verbatimEnvironments`:
    Regex support, treat `name` as regex. The following setting (https://github.com/cmhughes/latexindent.pl/issues/288#issuecomment-925701506):

    ```yaml
    verbatimEnvironments:
        minted*: 1
        '\w+code*?': 1
    ```
    
    will treat `*` as literal, and same issue for `noIndentBlock: abc*: 1`. If the user wants to use regex (`\*`):
    
    ```yaml
    verbatimEnvironments:
        mintedaliases:
            name: '\w+code\*?'
    ```

3. `name` for `verbatimCommands`:
    The only purpose is to making `verbatimCommands` settings to be similar to `verbatimEnvironments`. The following two are the same:

    ```yaml
    verbatimEnvironments:
        '\w+inline': 1

        mintinline:
            name: '\w+inline'
    ```

------

The second commit:

Add update `defaultSettings.yaml` to resolve #288. I can revert it if you feel unhappy with it.

------

The third commit:

Add new test for regex-based `verbatimEnvironments` and nested minted code blocks.

------

The other things:

The document will need to be updated. Since `defaultSettings.yaml` has been changed and we need to update line numbers. But I don't know whether I need to update these manually or it can be done by a script.