### PR TITLE
Substitule quoted strings in `-y` / `--yaml` switches

### DIFF
--- a/documentation/demonstrations/replace1-r1.tex
+++ b/documentation/demonstrations/replace1-r1.tex
@@ -1,2 +1,2 @@
-Before text, pl.latexindent,
+Before text, latexindent.pl,
 after text.


### PR DESCRIPTION
Current behavior:

1. Remove double quotes around double-quoted strings.
2. Only special treatment for quoted strings only with tabs.

Fail on strings using single quotations.

New behavior:

1. Always remove quotations around.
2. Substitute escape characters for `\t` / `\n` / `\"` / `\\` in double-quoted strings and `\t` / `\n` in single-quoted strings.

Fixes #296