### PR TITLE
Add Dockerfile and its updater/releaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release GHCR Package
+
+on:
+  push:
+    tags:
+      - 'V*'
+
+jobs:
+  ghcr:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: get tag
+        run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            LATEXINDENT_VERSION=${{ env.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=match,pattern=V(.*),group=1
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,3 +14,11 @@
   args: ["--overwriteIfDifferent", "--silent", "--local"]
   language: conda
   types: [tex]
+- id: latexindent-docker
+  name: latexindent.pl
+  description: Run latexindent.pl (get dependencies using Docker)
+  minimum_pre_commit_version: 2.1.0
+  entry: ghcr.io/cmhughes/latexindent.pl
+  language: docker_image
+  types: [tex]
+  args: ["--overwriteIfDifferent", "--silent", "--local"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
 FROM perl:5.36.0-slim-threaded-buster
 
+# Build:
+#   docker build . \
+#     -t <maintainer>/latexindent:<version tag> \
+#     --build-arg LATEXINDENT_VERSION=<version tag>
+#
+# Run:
+#   docker run --rm -it <maintainer>/latexindent:<version tag> -h
+#
+# Publish:
+#   docker push <maintainer>/latexindent:<version tag>
+
+ARG LATEXINDENT_VERSION
+ENV LATEXINDENT_VERSION ${LATEXINDENT_VERSION:-V3.17.3}
+
 RUN apt-get update \
     && apt-get install \
     build-essential \
@@ -15,7 +29,7 @@ RUN git clone --depth 1 https://github.com/cmhughes/latexindent.pl
 
 WORKDIR /latexindent.pl/helper-scripts
 
-RUN echo "Y" | perl latexindent-module-installer.pl
+RUN git checkout "${LATEXINDENT_VERSION}" && echo "Y" | perl latexindent-module-installer.pl
 
 WORKDIR /latexindent.pl/build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM perl:5.36.0-slim-threaded-buster
+
+RUN apt-get update \
+    && apt-get install \
+    build-essential \
+    ca-certificates \
+    cmake \
+    git \
+    wget \
+    -y -qq --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/cmhughes/latexindent.pl
+
+WORKDIR /latexindent.pl/helper-scripts
+
+RUN echo "Y" | perl latexindent-module-installer.pl
+
+WORKDIR /latexindent.pl/build
+
+RUN cmake ../path-helper-files && make install && ln -s /usr/local/bin/latexindent.pl /usr/local/bin/latexindent
+
+WORKDIR /
+
+ENTRYPOINT ["latexindent"]

--- a/documentation/demonstrations/pre-commit-config-docker.yaml
+++ b/documentation/demonstrations/pre-commit-config-docker.yaml
@@ -1,0 +1,5 @@
+- repo: https://github.com/cmhughes/latexindent.pl
+  rev: V3.17.3
+  hooks:
+    - id: latexindent-docker
+      args: [-s]

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -377,7 +377,7 @@ latexindent.pl myfile*.tex --check
   \begin{commandshell}
 conda install latexindent.pl -c conda-forge
 \end{commandshell}
-  this will install the executable and all its dependencies (including perl) in the
+  This will install the executable and all its dependencies (including perl) in the
   activate environment. You don't even have to worry about \texttt{defaultSettings.yaml} as
   it included too, you can thus skip \cref{sec:requiredmodules,sec:updating-path}.
   \index{conda}
@@ -397,7 +397,37 @@ conda run latexindent.pl -vv
 \end{commandshell}
   I found the details given at \cite{condainstallhelp} to be helpful.
 
- \section{pre-commit}
+ \section{Using docker}\label{sec:app:docker}
+  If you use docker you'll only need
+  \begin{commandshell}
+docker pull ghcr.io/cmhughes/latexindent.pl
+\end{commandshell}
+  This will download the image packed latexindent's executable and its all dependencies.
+  \index{docker}
+
+ \subsection{Sample docker installation on Ubuntu}
+  To pull the image and show latexindex's help on Ubuntu:
+  \begin{commandshell}
+# setup docker if you didn't yet
+if ! command -v docker &> /dev/null; then
+  sudo apt install docker.io -y
+  sudo groupadd docker
+  sudo gpasswd -a "$USER" docker
+  sudo systemctl restart docker
+fi
+
+# download image and execute
+docker pull ghcr.io/cmhughes/latexindent.pl
+docker run ghcr.io/cmhughes/latexindent.pl -h
+\end{commandshell}
+
+ \subsection{How to format on Docker}
+   When you use latexindent with the docker image, you have to mount target \texttt{tex} file like this:
+\begin{commandshell}
+  docker run -v /path/to/local/myfile.tex:/myfile.tex ghcr.io/cmhughes/latexindent.pl -s -w myfile.tex
+\end{commandshell}
+
+\section{pre-commit}
 
   Users of \texttt{.git} may be interested \announce{2022-01-21}{pre-commit for
   latexindent.pl} in exploring the \texttt{pre-commit} tool \cite{pre-commithome}, which is
@@ -495,7 +525,33 @@ conda run latexindent.pl -s myfile.tex
          can update \cref{lst:.pre-commit-config.yaml-cpan} so that \texttt{args: [-s, -w]}.
   \end{itemize}
 
- \subsection{pre-commit example using -l, -m switches}
+  \subsection{pre-commit using docker}\label{sec:pre-commit-docker}
+
+  You can also rely on \texttt{docker} (detailed in \cref{sec:app:docker}) instead of
+  \texttt{CPAN} for all dependencies, including \texttt{latexindent.pl} itself.
+  \index{docker} \index{git} \index{pre-commit!docker}
+
+  \cmhlistingsfromfile{demonstrations/pre-commit-config-docker.yaml}[yaml-TCB]{\texttt{.pre-commit-config.yaml} (docker)}{lst:.pre-commit-config.yaml-docker}
+  Once created, you should then be able to run the following command:
+  \begin{commandshell}
+pre-commit run --all-files
+\end{commandshell}
+  A few notes about \cref{lst:.pre-commit-config.yaml-cpan}:
+  \begin{itemize}
+   \item the settings given in \cref{lst:.pre-commit-config.yaml-docker} instruct
+         \texttt{pre-commit} to use \texttt{docker} to get dependencies;
+   \item this requires \texttt{pre-commit} and \texttt{docker} to be installed on your system;
+   \item the \texttt{args} lists selected command-line options; the settings in
+         \cref{lst:.pre-commit-config.yaml-cpan} are equivalent to calling
+         \begin{commandshell}
+docker run -v /path/to/myfile.tex:/myfile.tex ghcr.io/cmhughes/latexindent.pl -s myfile.tex
+\end{commandshell}
+         for each \texttt{.tex} file in your repository;
+   \item to instruct \texttt{latexindent.pl} to overwrite the files in your repository, then you
+         can update \cref{lst:.pre-commit-config.yaml-cpan} so that \texttt{args: [-s, -w]}.
+  \end{itemize}
+
+  \subsection{pre-commit example using -l, -m switches}
   Let's consider a small example, with local \texttt{latexindent.pl} settings in
   \texttt{.latexindent.yaml}.
 

--- a/readme.md
+++ b/readme.md
@@ -111,8 +111,17 @@ You don't even have to worry about `defaultSettings.yaml` as it included too.
 	
 > [![Conda Version](https://img.shields.io/conda/vn/conda-forge/latexindent.pl.svg)](https://anaconda.org/conda-forge/latexindent.pl)
 </details>
+<details>
+<summary>docker users</summary>
+If you use latexindent via docker you'll only need
+
+    docker pull ghcr.io/cmhughes/latexindent.pl
+    docker run -v /path/to/local/myfile.tex:/myfile.tex --rm -it ghcr.io/cmhughes/latexindent.pl -s -w myfile.tex
+
+</details>
 
 ## pre-commit
+
 You can use `latexindent` with the [pre-commit
 framework](https://pre-commit.com) by adding this to your
 `.pre-commit-config.yaml`:


### PR DESCRIPTION
ref: #369 

```shellsession
$ docker build . -t eggplanter/latexindent:3.17.3 --build-arg LATEXINDENT_VERSION=V3.17.3
...
Successfully tagged eggplanter/latexindent:3.17.3

$ docker run --rm -it eggplanter/latexindent:3.17.3 -h
latexindent.pl version 3.17.3, 2022-06-05
usage: latexindent.pl [options] [file]
      -v, --version
          displays the version number and date of release
...
```