### PR TITLE
Adding the additional dependency for Arch users in the documentation

### DIFF
--- a/documentation/sec-appendices.rst
+++ b/documentation/sec-appendices.rst
@@ -144,6 +144,13 @@ First install the dependencies
 
    sudo pacman -S perl cpanminus
 
+In addition, install ``perl-file-homedir`` from AUR, using your AUR helper of choice,
+
+.. code-block:: latex
+   :class: .commandshell
+
+   sudo paru -S perl-file-homedir
+
 then run the latexindent-module-installer.pl file located at helper-scripts/
 
 Alpine


### PR DESCRIPTION
what is this pull request about?
-
Arch users need to install `perl-file-homedir` from AUR as a dependency.

does this relate to an existing issue?
-
[Can't locate File/HomeDir.pm #2](https://github.com/cmhughes/latexindent.pl/issues/2#issuecomment-1159140506)

does this change any existing behaviour?
-
no

what does this add?
-
added few lines of instruction in the `sec-appendices.rst` file.

how do I test this?
-
Test is not relevant for this issue.