### PR TITLE
Added support for the XDG specification

### DIFF
--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -130,27 +130,27 @@ sub yaml_read_settings {
     }
     # see all possible values of $^O here: https://perldoc.perl.org/perlport#Unix and https://perldoc.perl.org/perlport#DOS-and-Derivatives
     if ($^O eq "linux") {
-        if (!defined $indentconfig && defined $ENV{XDG_CONFIG_HOME} && -f "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml") {
-            $indentconfig = "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml";
-            $logger->info('The $XDG_CONFIG_HOME variable and the config file in "' . "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml" . '" were recognized') unless $switches{onlyDefault};
+        if (!defined $indentconfig && defined $ENV{XDG_CONFIG_HOME} && -f "$ENV{XDG_CONFIG_HOME}/latexindent/indentconfig.yaml") {
+            $indentconfig = "$ENV{XDG_CONFIG_HOME}/latexindent/indentconfig.yaml";
+            $logger->info('The $XDG_CONFIG_HOME variable and the config file in "' . "$ENV{XDG_CONFIG_HOME}/latexindent/indentconfig.yaml" . '" were recognized') unless $switches{onlyDefault};
             $logger->info('The value of $XDG_CONFIG_HOME is: "' . $ENV{XDG_CONFIG_HOME} . '"') unless $switches{onlyDefault};
-        } elsif (!defined $indentconfig && -f "$homeDir/.config/latexindent/latexindent.yaml") {
-            $indentconfig = "$homeDir/.config/latexindent/latexindent.yaml";
-            $logger->info('The config file in "' . "$homeDir/.config/latexindent/latexindent.yaml" . '" was recognized') unless $switches{onlyDefault};
+        } elsif (!defined $indentconfig && -f "$homeDir/.config/latexindent/indentconfig.yaml") {
+            $indentconfig = "$homeDir/.config/latexindent/indentconfig.yaml";
+            $logger->info('The config file in "' . "$homeDir/.config/latexindent/indentconfig.yaml" . '" was recognized') unless $switches{onlyDefault};
         }
     } elsif ($^O eq "darwin") {
-        if (!defined $indentconfig && -f "$homeDir/Library/Preferences/latexindent/latexindent.yaml")  {
-            $indentconfig = "$homeDir/Library/Preferences/latexindent/latexindent.yaml";
-            $logger->info('The config file in "' . "$homeDir/Library/Preferences/latexindent/latexindent.yaml" . '" was recognized') unless $switches{onlyDefault};
+        if (!defined $indentconfig && -f "$homeDir/Library/Preferences/latexindent/indentconfig.yaml")  {
+            $indentconfig = "$homeDir/Library/Preferences/latexindent/indentconfig.yaml";
+            $logger->info('The config file in "' . "$homeDir/Library/Preferences/latexindent/indentconfig.yaml" . '" was recognized') unless $switches{onlyDefault};
         }
     } elsif ($^O eq "MSWin32" || $^O eq "cygwin") {
-        if (!defined $indentconfig && defined $ENV{LOCALAPPDATA} && -f "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml") {
-            $indentconfig = "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml";
-            $logger->info('The $LOCALAPPDATA variable and the config file in "' . "$ENV{LOCALAPPDATA}" . '\latexindent\latexindent.yaml" were recognized') unless $switches{onlyDefault};
+        if (!defined $indentconfig && defined $ENV{LOCALAPPDATA} && -f "$ENV{LOCALAPPDATA}/latexindent/indentconfig.yaml") {
+            $indentconfig = "$ENV{LOCALAPPDATA}/latexindent/indentconfig.yaml";
+            $logger->info('The $LOCALAPPDATA variable and the config file in "' . "$ENV{LOCALAPPDATA}" . '\latexindent\indentconfig.yaml" were recognized') unless $switches{onlyDefault};
             $logger->info('The value of $LOCALAPPDATA is: "' . $ENV{LOCALAPPDATA} . '"') unless $switches{onlyDefault};
-        } elsif (!defined $indentconfig && -f "$homeDir/AppData/Local/latexindent/latexindent.yaml") {
-            $indentconfig = "$homeDir/AppData/Local/latexindent/latexindent.yaml";
-            $logger->info('The config file in "' . "$homeDir" . '\AppData\Local\latexindent\latexindent.yaml" was recognized') unless $switches{onlyDefault};
+        } elsif (!defined $indentconfig && -f "$homeDir/AppData/Local/latexindent/indentconfig.yaml") {
+            $indentconfig = "$homeDir/AppData/Local/latexindent/indentconfig.yaml";
+            $logger->info('The config file in "' . "$homeDir" . '\AppData\Local\latexindent\indentconfig.yaml" was recognized') unless $switches{onlyDefault};
         }
     }
     if ( !defined $indentconfig ) {

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -117,12 +117,20 @@ sub yaml_read_settings {
 
     # we'll need the home directory a lot in what follows
     my $homeDir = File::HomeDir->my_home;
-    $logger->info("*YAML settings read: indentconfig.yaml or .indentconfig.yaml") unless $switches{onlyDefault};
+     $logger->info("*YAML reading seittings") unless $switches{onlyDefault};
 
-    my $indentconfig = defined $ENV{LATEXINDENT_CONFIG} ? $ENV{LATEXINDENT_CONFIG} : undef;
+    my $indentconfig = undef;
+    if ( defined $ENV{LATEXINDENT_CONFIG} ) {
+        if(-f $ENV{LATEXINDENT_CONFIG}) {
+            $indentconfig = $ENV{LATEXINDENT_CONFIG};
+        } else {
+             $logger->info('The $LATEXINDENT_CONFIG variable is assigned, but does not point to a file!') unless $switches{onlyDefault};
+            $logger->info('The value of $LATEXINDENT_CONFIG is: "' . $ENV{LATEXINDENT_CONFIG} . '"');
+        }
+    }
     # see all possible values of $^O here: https://perldoc.perl.org/perlport#Unix and https://perldoc.perl.org/perlport#DOS-and-Derivatives
     if ($^O eq "linux") {
-        if (!defined $indentconfig && defined "$ENV{XDG_CONFIG_HOME}" && -f "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml") {
+        if (!defined $indentconfig && defined $ENV{XDG_CONFIG_HOME} && -f "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml") {
             $indentconfig = "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml";
         } elsif (!defined $indentconfig && -f "$homeDir/.config/latexindent/latexindent.yaml") {
             $indentconfig = "$homeDir/.config/latexindent/latexindent.yaml";
@@ -132,7 +140,7 @@ sub yaml_read_settings {
             $indentconfig = "$homeDir/Library/Preferences/latexindent/latexindent.yaml";
         }
     } elsif ($^O eq "MSWin32" || $^O eq "cygwin") {
-        if (!defined $indentconfig && "$ENV{LOCALAPPDATA}" && -f "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml") {
+        if (!defined $indentconfig && defined $ENV{LOCALAPPDATA} && -f "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml") {
             $indentconfig = "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml";
         } elsif (!defined $indentconfig && -f "$homeDir/AppData/Local/latexindent/latexindent.yaml") {
             $indentconfig = "$homeDir/AppData/Local/latexindent/latexindent.yaml";
@@ -147,7 +155,7 @@ sub yaml_read_settings {
 
 
     # messages for indentconfig.yaml and/or .indentconfig.yaml
-    if ( defined $indentconfig && -f $indentconfig and !$switches{onlyDefault} ) {
+    if ( defined $indentconfig && -f $indentconfig && !$switches{onlyDefault} ) {
 
         # read the absolute paths from indentconfig.yaml
         $userSettings = YAML::Tiny->read("$indentconfig");
@@ -219,9 +227,9 @@ sub yaml_read_settings {
             $switches{yaml}              = 0;
         }
         else {
-            # give the user instructions on where to put indentconfig.yaml or .indentconfig.yaml
+            # give the user instructions on where to put the config file
             $logger->info(
-                "Home directory is $homeDir (didn't find either indentconfig.yaml or .indentconfig.yaml)\nTo specify user settings you would put indentconfig.yaml here: $homeDir/indentconfig.yaml\nAlternatively, you can use the hidden file .indentconfig.yaml as: $homeDir/.indentconfig.yaml"
+                "Home directory is $homeDir (didn't find a config file, see all posible locations here: https://latexindentpl.readthedocs.io/en/latest/sec-appendices.html#indentconfig-options)"
             );
         }
     }

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -119,12 +119,7 @@ sub yaml_read_settings {
     my $homeDir = File::HomeDir->my_home;
     $logger->info("*YAML settings read: indentconfig.yaml or .indentconfig.yaml") unless $switches{onlyDefault};
 
-    my $indentconfig = undef;
-    if (defined "$ENV{LATEXINDENT_CONFIG}" && length "$ENV{LATEXINDENT_CONFIG}" > 0) {
-        $indentconfig = "$ENV{LATEXINDENT_CONFIG}";
-    } else {
-        $indentconfig = undef;
-    }
+    my $indentconfig = defined $ENV{LATEXINDENT_CONFIG} ? $ENV{LATEXINDENT_CONFIG} : undef;
     # see all possible values of $^O here: https://perldoc.perl.org/perlport#Unix and https://perldoc.perl.org/perlport#DOS-and-Derivatives
     if ($^O eq "linux") {
         if (!defined $indentconfig && defined "$ENV{XDG_CONFIG_HOME}" && -f "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml") {

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -119,8 +119,17 @@ sub yaml_read_settings {
     my $homeDir = File::HomeDir->my_home;
     $logger->info("*YAML settings read: indentconfig.yaml or .indentconfig.yaml") unless $switches{onlyDefault};
 
-    # get information about user settings- first check if indentconfig.yaml exists
-    my $indentconfig = "$homeDir/indentconfig.yaml";
+    # get information about user settings- first check if the environment variable LATEXINDENT_CONFIG exists
+    my $indentconfig = "$ENV{LATEXINDENT_CONFIG}";
+
+    # if LATEXINDENT_CONFIG doesn't exist, check for the XDG_CONFIG_HOME path
+    $indentconfig = "$ENV{XDG_CONFIG_HOME}/latexindent/indentconfig.yaml" if ( !-e $indentconfig );
+
+    # or, if XDG_CONFIG_HOME isn't set, check HOME/.config
+    $indentconfig = "$ENV{HOME}/.config/latexindent/indentconfig.yaml" if ( !-e $indentconfig );
+
+    # if all of these don't exist check home directly, with the non hidden file
+    $indentconfig = "$homeDir/indentconfig.yaml" if ( !-e $indentconfig );
 
     # if indentconfig.yaml doesn't exist, check for the hidden file, .indentconfig.yaml
     $indentconfig = "$homeDir/.indentconfig.yaml" if ( !-e $indentconfig );

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -140,14 +140,14 @@ sub yaml_read_settings {
     }
     if ( !defined $indentconfig ) {
         # if all of these don't exist check home directly, with the non hidden file
-        $indentconfig = "$homeDir/indentconfig.yaml" if ( !-e $indentconfig );
+        $indentconfig = (-f "$homeDir/indentconfig.yaml") ? "$homeDir/indentconfig.yaml" : undef;
         # if indentconfig.yaml doesn't exist, check for the hidden file, .indentconfig.yaml
-        $indentconfig = "$homeDir/.indentconfig.yaml" if ( !-e $indentconfig );
+        $indentconfig = (-f "$homeDir/.indentconfig.yaml") ? "$homeDir/.indentconfig.yaml" : undef;
     }
 
 
     # messages for indentconfig.yaml and/or .indentconfig.yaml
-    if ( -e $indentconfig and !$switches{onlyDefault} ) {
+    if ( defined $indentconfig && -f $indentconfig and !$switches{onlyDefault} ) {
 
         # read the absolute paths from indentconfig.yaml
         $userSettings = YAML::Tiny->read("$indentconfig");
@@ -211,7 +211,7 @@ sub yaml_read_settings {
     else {
         if ( $switches{onlyDefault} ) {
             $logger->info("*-d switch active: only default settings requested");
-            $logger->info("not reading USER settings from $indentconfig") if ( -e $indentconfig );
+            $logger->info("not reading USER settings from $indentconfig") if ( defined $indentconfig &&  -e $indentconfig );
             $logger->info("Ignoring the -l switch: $switches{readLocalSettings} (you used the -d switch)")
                 if ( $switches{readLocalSettings} );
             $logger->info("Ignoring the -y switch: $switches{yaml} (you used the -d switch)") if ( $switches{yaml} );

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -125,25 +125,32 @@ sub yaml_read_settings {
             $indentconfig = $ENV{LATEXINDENT_CONFIG};
         } else {
              $logger->info('The $LATEXINDENT_CONFIG variable is assigned, but does not point to a file!') unless $switches{onlyDefault};
-            $logger->info('The value of $LATEXINDENT_CONFIG is: "' . $ENV{LATEXINDENT_CONFIG} . '"');
+             $logger->info('The value of $LATEXINDENT_CONFIG is: "' . $ENV{LATEXINDENT_CONFIG} . '"') unless $switches{onlyDefault};
         }
     }
     # see all possible values of $^O here: https://perldoc.perl.org/perlport#Unix and https://perldoc.perl.org/perlport#DOS-and-Derivatives
     if ($^O eq "linux") {
         if (!defined $indentconfig && defined $ENV{XDG_CONFIG_HOME} && -f "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml") {
             $indentconfig = "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml";
+            $logger->info('The $XDG_CONFIG_HOME variable and the config file in "' . "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml" . '" were recognized') unless $switches{onlyDefault};
+            $logger->info('The value of $XDG_CONFIG_HOME is: "' . $ENV{XDG_CONFIG_HOME} . '"') unless $switches{onlyDefault};
         } elsif (!defined $indentconfig && -f "$homeDir/.config/latexindent/latexindent.yaml") {
             $indentconfig = "$homeDir/.config/latexindent/latexindent.yaml";
+            $logger->info('The config file in "' . "$homeDir/.config/latexindent/latexindent.yaml" . '" was recognized') unless $switches{onlyDefault};
         }
     } elsif ($^O eq "darwin") {
         if (!defined $indentconfig && -f "$homeDir/Library/Preferences/latexindent/latexindent.yaml")  {
             $indentconfig = "$homeDir/Library/Preferences/latexindent/latexindent.yaml";
+            $logger->info('The config file in "' . "$homeDir/Library/Preferences/latexindent/latexindent.yaml" . '" was recognized') unless $switches{onlyDefault};
         }
     } elsif ($^O eq "MSWin32" || $^O eq "cygwin") {
         if (!defined $indentconfig && defined $ENV{LOCALAPPDATA} && -f "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml") {
             $indentconfig = "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml";
+            $logger->info('The $LOCALAPPDATA variable and the config file in "' . "$ENV{LOCALAPPDATA}" . '\latexindent\latexindent.yaml" were recognized') unless $switches{onlyDefault};
+            $logger->info('The value of $LOCALAPPDATA is: "' . $ENV{LOCALAPPDATA} . '"') unless $switches{onlyDefault};
         } elsif (!defined $indentconfig && -f "$homeDir/AppData/Local/latexindent/latexindent.yaml") {
             $indentconfig = "$homeDir/AppData/Local/latexindent/latexindent.yaml";
+            $logger->info('The config file in "' . "$homeDir" . '\AppData\Local\latexindent\latexindent.yaml" was recognized') unless $switches{onlyDefault};
         }
     }
     if ( !defined $indentconfig ) {
@@ -151,6 +158,7 @@ sub yaml_read_settings {
         $indentconfig = (-f "$homeDir/indentconfig.yaml") ? "$homeDir/indentconfig.yaml" : undef;
         # if indentconfig.yaml doesn't exist, check for the hidden file, .indentconfig.yaml
         $indentconfig = (-f "$homeDir/.indentconfig.yaml") ? "$homeDir/.indentconfig.yaml" : undef;
+        $logger->info('The config file in "' . "$indentconfig" . '" was recognized') if defined $indentconfig && ! $switches{onlyDefault};
     }
 
 

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -124,14 +124,14 @@ sub yaml_read_settings {
     if ($^O eq "linux") {
         if (!defined $indentconfig && defined "$ENV{XDG_CONFIG_HOME}" && -f "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml") {
             $indentconfig = "$ENV{XDG_CONFIG_HOME}/latexindent/latexindent.yaml";
-        } elsif (!defined $indentconfig && defined "$ENV{HOME}" && -f "$ENV{HOME}/.config/latexindent/latexindent.yaml") {
-            $indentconfig = "$ENV{HOME}/.config/latexindent/latexindent.yaml";
+        } elsif (!defined $indentconfig && -f "$homeDir/.config/latexindent/latexindent.yaml") {
+            $indentconfig = "$homeDir/.config/latexindent/latexindent.yaml";
         }
     } elsif ($^O eq "darwin") {
-        if (!defined $indentconfig && -f "$homeDir/Library/Preferences/latexindent")  {
-            $indentconfig = "$homeDir/Library/Preferences/latexindent";
+        if (!defined $indentconfig && -f "$homeDir/Library/Preferences/latexindent/latexindent.yaml")  {
+            $indentconfig = "$homeDir/Library/Preferences/latexindent/latexindent.yaml";
         }
-    } elsif ($^O eq "MSWin32" || $^O == "cygwin") {
+    } elsif ($^O eq "MSWin32" || $^O eq "cygwin") {
         if (!defined $indentconfig && "$ENV{LOCALAPPDATA}" && -f "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml") {
             $indentconfig = "$ENV{LOCALAPPDATA}/latexindent/latexindent.yaml";
         } elsif (!defined $indentconfig && -f "$homeDir/AppData/Local/latexindent/latexindent.yaml") {

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -702,7 +702,7 @@ latexindent.pl -l -m -s -w myfile.tex
   \end{enumerate}
   \subsection{Why to change the configuration location}
   This is mostly a question about what you prefer, some like to put all their configuration files in their home directory (see \texttt{\$homeDir} above),
-  whilst some like to sort their configuration. And if you don't care about it, you can just continue using the sane defaults.
+  whilst some like to sort their configuration. And if you don't care about it, you can just continue using the same defaults.
   \subsection{How to change the configuration location}
   This depends on your preferred location, if, for example, you would like to set a custom location, you would have to change the \texttt{\$LATEXINDENT\_CONFIG} environment variable.
    \subsubsection{Linux}
@@ -714,9 +714,11 @@ echo 'export LATEXINDENT_CONFIG="/your/config/path"' >> ~/.profile
     All commands in this file a run after login, so the environment variable will be set after your next login.
    \subsubsection{Windows}
     To change it on Windows run following command in \texttt{powershell.exe}:
+    \begin{widepage}
     \begin{dosprompt}
 [Environment]::SetEnvironmentVariable("LATEXINDENT_CONFIG", "\your\config\path", "User")
     \end{dosprompt}
+    \end{widepage}
     This sets the environment variable for every user session.
    \subsubsection{Mac}
     In a terminal type:

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -684,13 +684,13 @@ latexindent.pl -l -m -s -w myfile.tex
         \begin{itemize}
           \item Linux:
               \begin{enumerate}
-                  \item The file at \texttt{\$XDG\_CONFIG\_HOME/latexindent/indentconfig.yaml}
-                  \item The file at \texttt{\$homeDir/.config/latexindent/indentconfig.yaml}
+                  \item The file at \texttt{\$XDG\_CONFIG\_HOME/latexindent/latexindent.yaml}
+                  \item The file at \texttt{\$homeDir/.config/latexindent/latexindent.yaml}
               \end{enumerate}
           \item Windows:
               \begin{enumerate}
-                  \item The file at \texttt{\$LOCALAPPDATA\textbackslash{}latexindent\textbackslash{}indentconfig.yaml}
-                  \item The file at \texttt{\$homeDir\textbackslash{}AppData\textbackslash{}Local\textbackslash{}latexindent\textbackslash{}indentconfig.yaml}
+                  \item The file at \texttt{\$LOCALAPPDATA\textbackslash{}latexindent\textbackslash{}latexindent.yaml}
+                  \item The file at \texttt{\$homeDir\textbackslash{}AppData\textbackslash{}Local\textbackslash{}latexindent\textbackslash{}latexindent.yaml}
               \end{enumerate}
           \item Mac:
               \begin{enumerate}
@@ -700,6 +700,31 @@ latexindent.pl -l -m -s -w myfile.tex
     \item The file at \texttt{\$homeDir/.indentconfig.yaml}
     \item The file at \texttt{\$homeDir/indentconfig.yaml}
   \end{enumerate}
+  \subsection{Why to change the configuration location}
+  This is mostly a question about what you prefer, some like to put all their configuration files in their home directory (see \texttt{\$homeDir} above),
+  whilst some like to sort their configuration. And if you don't care about it, you can just continue using the sane defaults.
+  \subsection{How to change the configuration location}
+  This depends on your preferred location, if, for example, you would like to set a custom location, you would have to change the \texttt{\$LATEXINDENT\_CONFIG} environment variable.
+   \subsubsection{Linux}
+    To change it on Linux run the following command in a terminal, after changing the path:
+    \begin{commandshell}
+echo 'export LATEXINDENT_CONFIG="/your/config/path"' >> ~/.profile
+    \end{commandshell}
+    Context: This command adds the line \texttt{export LATEXINDENT\_CONFIG=``/your/config/path``} to your .profile file (which is commonly stored in \texttt{\$HOME/.profile}).
+    All commands in this file a run after login, so the environment variable will be set after your next login.
+   \subsubsection{Windows}
+    To change it on Windows run following command in \texttt{powershell.exe}:
+    \begin{dosprompt}
+[Environment]::SetEnvironmentVariable("LATEXINDENT_CONFIG", "\your\config\path", "User")
+    \end{dosprompt}
+    This sets the environment variable for every user session.
+   \subsubsection{Mac}
+    In a terminal type:
+    \begin{commandshell}
+echo 'export LATEXINDENT_CONFIG="/your/config/path"' >> ~/.profile
+    \end{commandshell}
+    Context: This command adds the line \texttt{export LATEXINDENT\_CONFIG=``/path/to/your/custom/configuration/file``} to your .profile file (which is commonly stored in \texttt{\$HOME/.profile}).
+    All commands in this file a run after login, so the environment variable will be set after your next login.
  \section{logFilePreferences}\label{app:logfile-demo}
   \Vref{lst:logFilePreferences} describes the options for customising the information given
   to the log file, and we provide a few demonstrations here.

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -684,17 +684,17 @@ latexindent.pl -l -m -s -w myfile.tex
         \begin{itemize}
           \item Linux:
               \begin{enumerate}
-                  \item The file at \texttt{\$XDG\_CONFIG\_HOME/latexindent/latexindent.yaml}
-                  \item The file at \texttt{\$homeDir/.config/latexindent/latexindent.yaml}
+                  \item The file at \texttt{\$XDG\_CONFIG\_HOME/latexindent/indentconfig.yaml}
+                  \item The file at \texttt{\$homeDir/.config/latexindent/indentconfig.yaml}
               \end{enumerate}
           \item Windows:
               \begin{enumerate}
-                  \item The file at \texttt{\$LOCALAPPDATA\textbackslash{}latexindent\textbackslash{}latexindent.yaml}
-                  \item The file at \texttt{\$homeDir\textbackslash{}AppData\textbackslash{}Local\textbackslash{}latexindent\textbackslash{}latexindent.yaml}
+                  \item The file at \texttt{\$LOCALAPPDATA\textbackslash{}latexindent\textbackslash{}indentconfig.yaml}
+                  \item The file at \texttt{\$homeDir\textbackslash{}AppData\textbackslash{}Local\textbackslash{}latexindent\textbackslash{}indentconfig.yaml}
               \end{enumerate}
           \item Mac:
               \begin{enumerate}
-                  \item The file at \texttt{\$homeDir/Library/Preferences/latexindent/latexindent.yaml}
+                  \item The file at \texttt{\$homeDir/Library/Preferences/latexindent/indentconfig.yaml}
               \end{enumerate}
         \end{itemize}
     \item The file at \texttt{\$homeDir/.indentconfig.yaml}

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -705,6 +705,9 @@ latexindent.pl -l -m -s -w myfile.tex
   whilst some like to sort their configuration. And if you don't care about it, you can just continue using the same defaults.
   \subsection{How to change the configuration location}
   This depends on your preferred location, if, for example, you would like to set a custom location, you would have to change the \texttt{\$LATEXINDENT\_CONFIG} environment variable.
+  Although the following example only covers \texttt{\$LATEXINDENT\_CONFIG},
+  the same process can be applied to \texttt{\$XDG\_CONFIG\_HOME} or \texttt{\$LOCALAPPDATA} because both are environment variables.
+You just have to change the path to your chosen configuration directory (e.g. \texttt{\$homeDir/.config} or \texttt{\$homeDir\textbackslash{}AppData\textbackslash{}Local} on Linux or Windows respectively)
    \subsubsection{Linux}
     To change it on Linux run the following command in a terminal, after changing the path:
     \begin{commandshell}

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -22,9 +22,9 @@ use strict;                         #     |
 use warnings;                       #     |
 use Encode;                         #     |
 use Getopt::Long;                   #     |
-use Data::Dumper;                   #  these modules are      
-use List::Util qw(max);             #  generally part         
-use PerlIO::encoding;               #  of a default perl distribution 
+use Data::Dumper;                   #  these modules are
+use List::Util qw(max);             #  generally part
+use PerlIO::encoding;               #  of a default perl distribution
 use open ':std', ':encoding(UTF-8)';#     |
 use Text::Wrap;                     #     |
 use Text::Tabs;                     #     |
@@ -103,7 +103,7 @@ sudo apt install texlive-latex-recommended
    may need the following additional command to work with \texttt{latexindent.pl}
 
    \begin{commandshell}
-sudo apt install texlive-extra-utils 
+sudo apt install texlive-extra-utils
 \end{commandshell}
 
   \paragraph{Ubuntu: users without perl}
@@ -175,7 +175,7 @@ cpanm File::HomeDir
   Alternatively,
 
   \begin{commandshell}
-brew install latexindent  
+brew install latexindent
 \end{commandshell}
 
   \texttt{latexindent-macos} is a standalone executable \announce*{2022-10-30}{macOS standalone executable} for macOS (and therefore does not require a Perl distribution)
@@ -292,7 +292,7 @@ echo %path%
   to operate on multiple files. For example, the following calls are all valid
 
   \begin{commandshell}
-latexindent.pl myfile1.tex          
+latexindent.pl myfile1.tex
 latexindent.pl myfile1.tex myfile2.tex
 latexindent.pl myfile*.tex
         \end{commandshell}
@@ -320,7 +320,7 @@ latexindent.pl -w myfile*.tex
   If \texttt{latexindent.pl} is called using the \texttt{-o} switch as in
 
   \begin{commandshell}
-latexindent.pl myfile*.tex -o=my-output-file.tex 
+latexindent.pl myfile*.tex -o=my-output-file.tex
         \end{commandshell}
 
   and there are multiple files to operate upon, then the \texttt{-o} switch is ignored
@@ -548,7 +548,7 @@ export PATH=$PATH:/home/cmhughes/.local/bin
   Once created, you should then be able to run the following command:
 
   \begin{commandshell}
-pre-commit run --all-files  
+pre-commit run --all-files
 \end{commandshell}
 
   A few notes about \cref{lst:.pre-commit-config.yaml-cpan}:
@@ -560,7 +560,7 @@ pre-commit run --all-files
          \cref{lst:.pre-commit-config.yaml-cpan} are equivalent to calling
 
          \begin{commandshell}
-latexindent.pl -s myfile.tex       
+latexindent.pl -s myfile.tex
 \end{commandshell}
 
          for each \texttt{.tex} file in your repository;
@@ -581,7 +581,7 @@ latexindent.pl -s myfile.tex
   Once created, you should then be able to run the following command:
 
   \begin{commandshell}
-pre-commit run --all-files  
+pre-commit run --all-files
 \end{commandshell}
 
   A few notes about \cref{lst:.pre-commit-config.yaml-cpan}:
@@ -593,7 +593,7 @@ pre-commit run --all-files
          \cref{lst:.pre-commit-config.yaml-cpan} are equivalent to calling
 
          \begin{commandshell}
-conda run latexindent.pl -s myfile.tex       
+conda run latexindent.pl -s myfile.tex
 \end{commandshell}
 
          for each \texttt{.tex} file in your repository;
@@ -651,7 +651,7 @@ modifyLineBreaks:
   Now running
 
   \begin{commandshell}
-pre-commit run --all-files  
+pre-commit run --all-files
 \end{commandshell}
 
   is equivalent to running
@@ -672,6 +672,34 @@ latexindent.pl -l -m -s -w myfile.tex
   \end{itemize}
   \end{example}
 
+ \section{indentconfig options}
+  This section describes the possible locations for the main configuration file.
+  The possible locations are evaluated one after the other, but evaluation stops
+  when a valid file is found in one of the paths. The following list shows the checked options and is sorted by their respective priority.
+  It uses capitalized and with a Dollar symbol prefixed names (e.g. \texttt{\$LATEXINDENT\_CONFIG}) to symbolize environment variables.
+  In addition to that the variable name \texttt{\$homeDir} is used to symbolize your home directory.
+  \begin{enumerate}
+      \item The value of the environment variable \texttt{\$LATEXINDENT\_CONFIG} is treated as highest priority source for the path to the configuration file.
+      \item The next options are dependent on your operating system:
+        \begin{itemize}
+          \item Linux:
+              \begin{enumerate}
+                  \item The file at \texttt{\$XDG\_CONFIG\_HOME/latexindent/indentconfig.yaml}
+                  \item The file at \texttt{\$homeDir/.config/latexindent/indentconfig.yaml}
+              \end{enumerate}
+          \item Windows:
+              \begin{enumerate}
+                  \item The file at \texttt{\$LOCALAPPDATA\textbackslash{}latexindent\textbackslash{}indentconfig.yaml}
+                  \item The file at \texttt{\$homeDir\textbackslash{}AppData\textbackslash{}Local\textbackslash{}latexindent\textbackslash{}indentconfig.yaml}
+              \end{enumerate}
+          \item Mac:
+              \begin{enumerate}
+                  \item The file at \texttt{\$homeDir/Library/Preferences/latexindent/latexindent.yaml}
+              \end{enumerate}
+        \end{itemize}
+    \item The file at \texttt{\$homeDir/.indentconfig.yaml}
+    \item The file at \texttt{\$homeDir/indentconfig.yaml}
+  \end{enumerate}
  \section{logFilePreferences}\label{app:logfile-demo}
   \Vref{lst:logFilePreferences} describes the options for customising the information given
   to the log file, and we provide a few demonstrations here.
@@ -691,7 +719,7 @@ latexindent.pl -l -m -s -w myfile.tex
   If we run the following command (noting that \texttt{-t} is active)
 
   \begin{commandshell}
-latexindent.pl -t -l=logfile-prefs1.yaml simple.tex 
+latexindent.pl -t -l=logfile-prefs1.yaml simple.tex
 \end{commandshell}
 
   then on inspection of \texttt{indent.log} we will find the snippet given in
@@ -763,10 +791,10 @@ latexindent.pl -o myfile.tex outputfile.tex
   \begin{commandshell}
 latexindent.pl -o=outputfile.tex myfile.tex
 latexindent.pl -o outputfile.tex myfile.tex
-latexindent.pl myfile.tex -o outputfile.tex 
-latexindent.pl myfile.tex -o=outputfile.tex 
-latexindent.pl myfile.tex -outputfile=outputfile.tex 
-latexindent.pl myfile.tex -outputfile outputfile.tex 
+latexindent.pl myfile.tex -o outputfile.tex
+latexindent.pl myfile.tex -o=outputfile.tex
+latexindent.pl myfile.tex -outputfile=outputfile.tex
+latexindent.pl myfile.tex -outputfile outputfile.tex
 \end{commandshell}
 
   noting that the \emph{output} file is given \emph{next to} the \texttt{-o} switch.


### PR DESCRIPTION
## what is this pull request about?
The search for the config file now includes the following directories, sorted by priority:
- `$LATEXINDENT_CONFIG`
- `$XDG_CONFIG_HOME/latexindent/indentconfig.yaml`
- `$HOME/.config/latexindent/indentconfig.yaml`
- `$homeDir/indentconfig.yaml`
- `$homeDir/.indentconfig.yaml`

`$homeDir` represents the users home OS-independently, whilst `$HOME` should only be set on Linux. 

## does this relate to an existing issue?
See Issue #396.

## does this change any existing behaviour?
yes, but only marginal.

## what does this add?
Support for the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), e. g. the config file can now be placed at:
- an arbitrary place, provided this location is specified in the `LATEXINDENT_CONFIG` environment variable
- _or_ the `$XDG_CONFIG_HOME/latexindent/indentconfig.yaml`
- _or_ `$HOME/.config/latexindent/indentconfig.yaml` 
- _or_ `$homeDir/indentconfig.yaml`
- _or_ `$homeDir/.indentconfig.yaml`

`$HOME` is referencing the HOME environment variable on Linux, whilst `$homeDir` is the OS-independent home value.


## how do I test this?
Assuming bash:
```bash
export LATEXINDENT_CONFIG="path/to/your/latexindent.yaml" # this can be any path
# put some noticeable changes in your letexindent.yaml file
latexindent <some tex file> # see that latexindent uses the settings, specified in your config file located at $LATEXINDENT_CONFIG 
```

## anything else?
This change should also be recorded in the documentation, but I have no idea in which files  the config file location is mentioned. 
