### PR TITLE
readme.md fixed to be rendered correctly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,7 @@ and also from [https://ctan.org/tex-archive/support/latexindent](https://ctan.or
 </details>
 <details>
 <summary>Linux users</summary>
+
 Please see the [Linux section of the appendix](https://latexindentpl.readthedocs.io/en/latest/sec-appendices.html#linux) 
 </details>
 <details>
@@ -113,6 +114,7 @@ and also from [https://ctan.org/tex-archive/support/latexindent](https://ctan.or
 </details>
 <details>
 <summary>Mac users</summary>
+
 Please see the [Mac section of the appendix](https://latexindentpl.readthedocs.io/en/latest/sec-appendices.html#mac)
 </details>
 <details>


### PR DESCRIPTION
what is this pull request about?
-
It appears that parts of `reamde.md` are not rendered correctly.

does this relate to an existing issue?
-
No.

does this change any existing behaviour?
-
No.

what does this add?
-
Added blank lines.

how do I test this?
-
Compare [here](https://github.com/cmhughes/latexindent.pl#getting-started) and [here](https://github.com/teatimeguest/latexindent.pl/tree/fix-md#getting-started).

anything else?
-
GFM Spec: [Example 131](https://github.github.com/gfm/#example-131) and [Example 137](https://github.github.com/gfm/#example-137).
