### PR TITLE
fix: find local settings when working file dir is not working dir

### DIFF
--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -328,7 +328,7 @@ sub yaml_read_settings {
         # if the -l switch is called on its own, or else with +
         # and latexindent.pl is called from a different directory, then
         # we need to account for this
-        if ( $_ eq "localSettings.yaml" ) {
+        if ( $_ =~ /^[.]?(localSettings|latexindent)\.yaml$/) {
 
             # check for existence in the directory of the file.
             if ( ( -e $workingFileLocation . "/" . $_ ) ) {

--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -328,7 +328,7 @@ sub yaml_read_settings {
         # if the -l switch is called on its own, or else with +
         # and latexindent.pl is called from a different directory, then
         # we need to account for this
-        if ( $_ =~ /^[.]?(localSettings|latexindent)\.yaml$/) {
+        if ( $_ =~ /^[.]?(localSettings|latexindent)\.yaml$/ ) {
 
             # check for existence in the directory of the file.
             if ( ( -e $workingFileLocation . "/" . $_ ) ) {

--- a/test-cases/batch-tests/batch-tests.sh
+++ b/test-cases/batch-tests/batch-tests.sh
@@ -33,5 +33,17 @@ latexindent.pl -l documentation.yaml -rv -w -m -s -g not-working.log doc*.tex
 latexindent.pl -s -l local-settings-friend-1/mwe.tex
 (cd local-settings-friend-1 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > localSettings.yaml))
 
+# local settings found with default name (friend #2)
+latexindent.pl -s -l local-settings-friend-2/mwe.tex
+(cd local-settings-friend-2 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > latexindent.yaml))
+
+# local settings found with default name (friend #3)
+latexindent.pl -s -l local-settings-friend-3/mwe.tex
+(cd local-settings-friend-3 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > .localSettings.yaml))
+
+# local settings found with default name (friend #4)
+latexindent.pl -s -l local-settings-friend-4/mwe.tex
+(cd local-settings-friend-4 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > .latexindent.yaml))  
+
 [[ $gitStatus == 1 ]] && git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/batch-tests/batch-tests.sh
+++ b/test-cases/batch-tests/batch-tests.sh
@@ -31,23 +31,23 @@ latexindent.pl -l documentation.yaml -rv -w -m -s -g not-working.log doc*.tex
 
 # local settings found with default name (friend #1)
 latexindent.pl -s -l local-settings-friend-1/mwe.tex
-(cd local-settings-friend-1 && (cat indent.log | grep "WARN" > warnings.txt))
+cat local-settings-friend-1/indent.log | grep "WARN" > local-settings-friend-1/warnings.txt
 
 # local settings found (friend #2)
 latexindent.pl -s -l local-settings-friend-2/mwe.tex
-(cd local-settings-friend-2 && (cat indent.log | grep "WARN" > warnings.txt))
+cat local-settings-friend-2/indent.log | grep "WARN" > local-settings-friend-2/warnings.txt
 
 # local settings found (friend #3)
 latexindent.pl -s -l local-settings-friend-3/mwe.tex
-(cd local-settings-friend-3 && (cat indent.log | grep "WARN" > warnings.txt))
+cat local-settings-friend-3/indent.log | grep "WARN" > local-settings-friend-3/warnings.txt
 
 # local settings found (friend #4)
 latexindent.pl -s -l local-settings-friend-4/mwe.tex
-(cd local-settings-friend-4 && (cat indent.log | grep "WARN" > warnings.txt))
+cat local-settings-friend-4/indent.log | grep "WARN" > local-settings-friend-4/warnings.txt
 
 # local settings not found (no friend; local settings file localSetting.yaml)
 latexindent.pl -s -l local-settings-nofriend/mwe.tex
-(cd local-settings-nofriend && (cat indent.log | grep "WARN" > warnings.txt))
+cat local-settings-nofriend/indent.log | grep "WARN" > local-settings-nofriend/warnings.txt
 
 [[ $gitStatus == 1 ]] && git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/batch-tests/batch-tests.sh
+++ b/test-cases/batch-tests/batch-tests.sh
@@ -45,5 +45,9 @@ latexindent.pl -s -l local-settings-friend-3/mwe.tex
 latexindent.pl -s -l local-settings-friend-4/mwe.tex
 (cd local-settings-friend-4 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > .latexindent.yaml))  
 
+# local settings not found (no friend; local settings file localSetting.yaml)
+latexindent.pl -s -l local-settings-nofriend/mwe.tex
+(cd local-settings-nofriend && (cat indent.log | grep "WARN" > warnings.txt))
+
 [[ $gitStatus == 1 ]] && git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/batch-tests/batch-tests.sh
+++ b/test-cases/batch-tests/batch-tests.sh
@@ -31,19 +31,19 @@ latexindent.pl -l documentation.yaml -rv -w -m -s -g not-working.log doc*.tex
 
 # local settings found with default name (friend #1)
 latexindent.pl -s -l local-settings-friend-1/mwe.tex
-(cd local-settings-friend-1 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > localSettings.yaml))
+(cd local-settings-friend-1 && (cat indent.log | grep "WARN" > warnings.txt))
 
 # local settings found (friend #2)
 latexindent.pl -s -l local-settings-friend-2/mwe.tex
-(cd local-settings-friend-2 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > latexindent.yaml))
+(cd local-settings-friend-2 && (cat indent.log | grep "WARN" > warnings.txt))
 
 # local settings found (friend #3)
 latexindent.pl -s -l local-settings-friend-3/mwe.tex
-(cd local-settings-friend-3 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > .localSettings.yaml))
+(cd local-settings-friend-3 && (cat indent.log | grep "WARN" > warnings.txt))
 
 # local settings found (friend #4)
 latexindent.pl -s -l local-settings-friend-4/mwe.tex
-(cd local-settings-friend-4 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > .latexindent.yaml))  
+(cd local-settings-friend-4 && (cat indent.log | grep "WARN" > warnings.txt))
 
 # local settings not found (no friend; local settings file localSetting.yaml)
 latexindent.pl -s -l local-settings-nofriend/mwe.tex

--- a/test-cases/batch-tests/batch-tests.sh
+++ b/test-cases/batch-tests/batch-tests.sh
@@ -33,15 +33,15 @@ latexindent.pl -l documentation.yaml -rv -w -m -s -g not-working.log doc*.tex
 latexindent.pl -s -l local-settings-friend-1/mwe.tex
 (cd local-settings-friend-1 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > localSettings.yaml))
 
-# local settings found with default name (friend #2)
+# local settings found (friend #2)
 latexindent.pl -s -l local-settings-friend-2/mwe.tex
 (cd local-settings-friend-2 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > latexindent.yaml))
 
-# local settings found with default name (friend #3)
+# local settings found (friend #3)
 latexindent.pl -s -l local-settings-friend-3/mwe.tex
 (cd local-settings-friend-3 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > .localSettings.yaml))
 
-# local settings found with default name (friend #4)
+# local settings found (friend #4)
 latexindent.pl -s -l local-settings-friend-4/mwe.tex
 (cd local-settings-friend-4 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > .latexindent.yaml))  
 

--- a/test-cases/batch-tests/batch-tests.sh
+++ b/test-cases/batch-tests/batch-tests.sh
@@ -28,5 +28,10 @@ latexindent.pl -s cmh.tex lines*.tex -g fatal-file-not-exist.log
 latexindent.pl -s cmh1.tex lines*.tex -g fatal-file-no-read.log
 
 latexindent.pl -l documentation.yaml -rv -w -m -s -g not-working.log doc*.tex
+
+# local settings found with default name (friend #1)
+latexindent.pl -s -l local-settings-friend-1/mwe.tex
+(cd local-settings-friend-1 && (cat indent.log | grep "defaultIndent" | sed 's/^ *//g' > localSettings.yaml))
+
 [[ $gitStatus == 1 ]] && git status
 [[ $noisyMode == 1 ]] && makenoise

--- a/test-cases/batch-tests/local-settings-friend-1/localSettings.yaml
+++ b/test-cases/batch-tests/local-settings-friend-1/localSettings.yaml
@@ -1,0 +1,1 @@
+defaultIndent: \t\t

--- a/test-cases/batch-tests/local-settings-friend-1/mwe.tex
+++ b/test-cases/batch-tests/local-settings-friend-1/mwe.tex
@@ -1,0 +1,16 @@
+\documentclass{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+
+\begin{document}
+
+\begin{equation}
+z
+={\left(
+x+
+y
+\right)}^2
+\end{equation}
+
+\end{document}

--- a/test-cases/batch-tests/local-settings-friend-1/warnings.txt
+++ b/test-cases/batch-tests/local-settings-friend-1/warnings.txt
@@ -1,0 +1,3 @@
+WARN:  yaml file not found: latexindent.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .localSettings.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .latexindent.yaml not found. Proceeding without it.

--- a/test-cases/batch-tests/local-settings-friend-2/latexindent.yaml
+++ b/test-cases/batch-tests/local-settings-friend-2/latexindent.yaml
@@ -1,0 +1,1 @@
+defaultIndent: \t\t

--- a/test-cases/batch-tests/local-settings-friend-2/mwe.tex
+++ b/test-cases/batch-tests/local-settings-friend-2/mwe.tex
@@ -1,0 +1,16 @@
+\documentclass{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+
+\begin{document}
+
+\begin{equation}
+z
+={\left(
+x+
+y
+\right)}^2
+\end{equation}
+
+\end{document}

--- a/test-cases/batch-tests/local-settings-friend-2/warnings.txt
+++ b/test-cases/batch-tests/local-settings-friend-2/warnings.txt
@@ -1,0 +1,3 @@
+WARN:  yaml file not found: localSettings.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .localSettings.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .latexindent.yaml not found. Proceeding without it.

--- a/test-cases/batch-tests/local-settings-friend-3/.localSettings.yaml
+++ b/test-cases/batch-tests/local-settings-friend-3/.localSettings.yaml
@@ -1,0 +1,1 @@
+defaultIndent: \t\t

--- a/test-cases/batch-tests/local-settings-friend-3/mwe.tex
+++ b/test-cases/batch-tests/local-settings-friend-3/mwe.tex
@@ -1,0 +1,16 @@
+\documentclass{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+
+\begin{document}
+
+\begin{equation}
+z
+={\left(
+x+
+y
+\right)}^2
+\end{equation}
+
+\end{document}

--- a/test-cases/batch-tests/local-settings-friend-3/warnings.txt
+++ b/test-cases/batch-tests/local-settings-friend-3/warnings.txt
@@ -1,0 +1,3 @@
+WARN:  yaml file not found: localSettings.yaml not found. Proceeding without it.
+WARN:  yaml file not found: latexindent.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .latexindent.yaml not found. Proceeding without it.

--- a/test-cases/batch-tests/local-settings-friend-4/.latexindent.yaml
+++ b/test-cases/batch-tests/local-settings-friend-4/.latexindent.yaml
@@ -1,0 +1,1 @@
+defaultIndent: \t\t

--- a/test-cases/batch-tests/local-settings-friend-4/mwe.tex
+++ b/test-cases/batch-tests/local-settings-friend-4/mwe.tex
@@ -1,0 +1,16 @@
+\documentclass{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+
+\begin{document}
+
+\begin{equation}
+z
+={\left(
+x+
+y
+\right)}^2
+\end{equation}
+
+\end{document}

--- a/test-cases/batch-tests/local-settings-friend-4/warnings.txt
+++ b/test-cases/batch-tests/local-settings-friend-4/warnings.txt
@@ -1,0 +1,3 @@
+WARN:  yaml file not found: localSettings.yaml not found. Proceeding without it.
+WARN:  yaml file not found: latexindent.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .localSettings.yaml not found. Proceeding without it.

--- a/test-cases/batch-tests/local-settings-nofriend/localSetting.yaml
+++ b/test-cases/batch-tests/local-settings-nofriend/localSetting.yaml
@@ -1,0 +1,1 @@
+defaultIndent: \t\t

--- a/test-cases/batch-tests/local-settings-nofriend/mwe.tex
+++ b/test-cases/batch-tests/local-settings-nofriend/mwe.tex
@@ -1,0 +1,16 @@
+\documentclass{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+
+\begin{document}
+
+\begin{equation}
+z
+={\left(
+x+
+y
+\right)}^2
+\end{equation}
+
+\end{document}

--- a/test-cases/batch-tests/local-settings-nofriend/warnings.txt
+++ b/test-cases/batch-tests/local-settings-nofriend/warnings.txt
@@ -1,0 +1,4 @@
+WARN:  yaml file not found: localSettings.yaml not found. Proceeding without it.
+WARN:  yaml file not found: latexindent.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .localSettings.yaml not found. Proceeding without it.
+WARN:  yaml file not found: .latexindent.yaml not found. Proceeding without it.


### PR DESCRIPTION
When latexindent is called with the `-l` switch on a file that is not in the current working directory, local settings in the same directory as this file are only found if it has the name `localSettings.yaml`; for the other four documented options `latexindent.yaml`, `.localSettings.yaml`, and `.latexindex.yaml`, the local settings files are not found or used (see #421).

The issue should be fixed by replacing the condition `$_ eq "localSettings.yaml"` by `$_ =~ /^[.]?(localSettings|latexindent)\.yaml$/` in the following part 

https://github.com/cmhughes/latexindent.pl/blob/f2b7b05b8c1606b1445aafae411e5238aee621ed/LatexIndent/GetYamlSettings.pm#L331-L342

does this relate to an existing issue?
-
Fix #421

does this change any existing behavior?
-
*yes/no*

what does this add?
-
See above.

how do I test this?
-
The behavior is documented with four tests in `test-cases/batch-tests`  that run latexindent on four subdirectories `test-cases/batch-tests/local-settings-friend-*`; each folder contains a local settings file with names `localSettings.yaml`, `latexindent.yaml`, `.localSettings.yaml`, and `.latexindent.yaml` and a small LaTeX file. The local settings only change `defaultIndent: "\t\t"`. The four tests run latexindent on the  LaTeX file, grep "defaultIndent", trim left spaces, and write the result to the local settings file; if everything works, the file should remain unchanged.
