### PR TITLE
fix: decode the name of the backup file

### DIFF
--- a/LatexIndent/BackUpFileProcedure.pm
+++ b/LatexIndent/BackUpFileProcedure.pm
@@ -23,6 +23,7 @@ use LatexIndent::LogFile qw/$logger/;
 use File::Basename;    # to get the filename and directory path
 use File::Copy;        # to copy the original file to backup (if overwrite option set)
 use Exporter qw/import/;
+use Encode qw/decode/;
 our @EXPORT_OK = qw/create_back_up_file check_if_different/;
 
 # copy main file to a back up in the case of the overwrite switch being active
@@ -48,7 +49,7 @@ sub create_back_up_file {
     my $backupFile = basename( ${$self}{fileName}, @fileExtensions );
 
     # add the user's backup directory to the backup path
-    $backupFile = "${$self}{cruftDirectory}/$backupFile";
+    $backupFile = decode("utf-8", "${$self}{cruftDirectory}/$backupFile");
 
     # local variables, determined from the YAML settings
     my $onlyOneBackUp       = $mainSettings{onlyOneBackUp};


### PR DESCRIPTION
what is this pull request about?
-
This pull request features a fix to a bug that occurs when working with LaTeX files whose names include characters with diacritics (e.g. å, ä, and ö that are used in Finnish and Swedish among many other languages).

does this relate to an existing issue?
-
No.

does this change any existing behaviour?
-
Yes.

what does this add?
-
When calling latexindent.pl with the `-w` flag, latexindent.pl will make a copy of the original file before overwriting it. However, if the file path contains characters with diacritics, latexindent.pl will not work, instead it prints an error message. For example, create a directory called `äö` and add a LaTeX file called `äö.tex` inside it. `äö.tex` can have the following content:
```tex
\begin{document}
Some text...
    \end{document}
```
When calling `latexindent.pl -w äö/äö.tex`, the following error message will be printed:
```
FATAL Could not write to backup file Ã¤Ã¶/Ã¤Ã¶.bak0. Please check permissions.
      Exiting, no indentation done.
```
With the fix that I made, the problem goes away and the output is how it's supposed to be:
```tex
\begin{document}
Some text...
\end{document}
```

how do I test this?
-
Please consider the example given above.

anything else?
-
Please notice that I have never written any Perl code before this. Nevertheless this seems to be working. Documentation about the `decode` method can be found [here](https://perldoc.perl.org/Encode#decode).