### PR TITLE
Add w.r.t to betterFullStop

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -666,6 +666,8 @@ fineTuning:
               (?:[iI]\.[eE])                # i.e OR I.e OR i.E OR I.E
               |                             #
               (?:etc)                       # etc
+              |                             #
+              (?:[wW]\.[rR]\.[tT])          # w.r.t OR W.r.t OR w.R.t OR w.r.T OR W.R.t OR W.r.T OR w.R.T OR W.R.T
             )                               #
           )                                 #
         )                                   # 


### PR DESCRIPTION
what is this pull request about?
-
Add `w.r.t.` to `betterFullStop` so that `modifyLineBreaks` does not break the sentence at `w.r.t.`

does this relate to an existing issue?
-
no

does this change any existing behaviour?
-
yes, will not break sentence at `w.r.t.`

what does this add?
-
currently `betterFullStop` includes `e.g.`, `i.e.`, `etc`, this PR adds `w.r.t` to it.

For example, 
```latex
The derivative of $F(x) = x^2$ w.r.t. $x$ is $2x$.
```

the currently result is
```latex
The derivative of $F(x) = x^2$ w.r.t.
$x$ is $2x$.
```
with this PR, the result is
```latex
The derivative of $F(x) = x^2$ w.r.t. $x$ is $2x$.
```

how do I test this?
-
1. apply this PR
2. copy the previous example to a file `a.tex`
3. create a file `localSettings.yaml` with content
    ```yaml
    modifyLineBreaks:
      oneSentencePerLine:
        manipulateSentences: 1
    ```
5. run with `latexindent -m -l a.tex`

anything else?
-
no
