### PR TITLE
Create cruft directory if it does not exist

### DIFF
--- a/LatexIndent/LogFile.pm
+++ b/LatexIndent/LogFile.pm
@@ -132,7 +132,13 @@ ENDQUOTE
 
     # if cruft directory does not exist, create it
     if ( !( -d ${$self}{cruftDirectory} ) ) {
-        make_path( ${$self}{cruftDirectory} );
+        eval { make_path( ${$self}{cruftDirectory} ) };
+        if ( $@ ) {
+            $logger->fatal( "*Could not create cruft directory " . decode( "utf-8", ${$self}{cruftDirectory} ) );
+            $logger->fatal("Exiting, no indentation done.");
+            $self->output_logfile();
+            exit(6);
+        }
     }
 
     my $logfileName = ( $switches{cruftDirectory} ? ${$self}{cruftDirectory} . "/" : '' )

--- a/LatexIndent/LogFile.pm
+++ b/LatexIndent/LogFile.pm
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use FindBin;
 use File::Basename;    # to get the filename and directory path
+use File::Path qw(make_path);
 use Exporter qw/import/;
 use LatexIndent::Switches qw/%switches/;
 use LatexIndent::Version qw/$versionNumber $versionDate/;
@@ -129,12 +130,9 @@ ENDQUOTE
     # cruft directory
     ${$self}{cruftDirectory} = $switches{cruftDirectory} || ( dirname ${$self}{fileName} );
 
-    # if cruft directory does not exist
+    # if cruft directory does not exist, create it
     if ( !( -d ${$self}{cruftDirectory} ) ) {
-        $logger->fatal( "*Could not find directory " . decode( "utf-8", ${$self}{cruftDirectory} ) );
-        $logger->fatal("Exiting, no indentation done.");
-        $self->output_logfile();
-        exit(6);
+        make_path( ${$self}{cruftDirectory} );
     }
 
     my $logfileName = ( $switches{cruftDirectory} ? ${$self}{cruftDirectory} . "/" : '' )

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -31,6 +31,7 @@ use Text::Tabs;                     #     |
 use FindBin;                        #     |
 use File::Copy;                     #     |
 use File::Basename;                 #     |
+use File::Path;                     #     |
 use File::HomeDir;                  # <--- typically requires install via cpanm
 use YAML::Tiny;                     # <--- typically requires install via cpanm
 

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -406,6 +406,8 @@ latexindent.pl -c=/path/to/directory/ myfile.tex
  than the current working directory, then you can send these `cruft' files to another
  directory. Note the use of a trailing forward slash. % this switch was made as a result of http://tex.stackexchange.com/questions/142652/output-latexindent-auxiliary-files-to-a-different-directory
 
+ If the cruft directory does not exist, it will be created by \texttt{latexindent.pl}.
+
 \flagbox{-g, --logfile=<name of log file>}
  \index{switches!-g, --logfile definition and details}
 
@@ -628,7 +630,7 @@ latexindent.pl myfile.tex
    3         & \faClose    & failure, myfile.tex not found                                                                 \\
    4         & \faClose    & failure, myfile.tex exists but cannot be read                                                 \\
    5         & \faClose    & failure, \texttt{-w} active, and back-up file cannot be written                               \\
-   6         & \faClose    & failure, \texttt{-c} active, and cruft directory does not exist                               \\
+   6         & \faClose    & failure, \texttt{-c} active, and cruft directory could not be created                         \\
    \bottomrule
   \end{tabular}
  \end{table}


### PR DESCRIPTION
what is this pull request about?
-
This creates the cruft directory if it does not already exist.

does this relate to an existing issue?
-
fixes: #452

how do I test this?
-
1. make sure the cruft directory does not exist.
2. run latexindent with `--cruft=...`
3. it should not raise an error and exit but create the directory and continue

anything else?
-
I've never written a line of Perl before, so please give feedback.

Also, is there any other place where the directory might be accessed and thus need to be created?
What about these places:
- https://github.com/cmhughes/latexindent.pl/blob/c702424c2c8152fe6fc33df6a1e9a54b55c36b88/LatexIndent/Document.pm#L274
- https://github.com/cmhughes/latexindent.pl/blob/c702424c2c8152fe6fc33df6a1e9a54b55c36b88/LatexIndent/BackUpFileProcedure.pm#L151