### PR TITLE
fix: update dockerfile for release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,13 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /
+
 RUN git clone --depth 7 https://github.com/cmhughes/latexindent.pl
 
 WORKDIR /latexindent.pl/helper-scripts
 
-RUN git checkout "${LATEXINDENT_VERSION}" && echo "Y" | perl latexindent-module-installer.pl
+RUN git fetch --tags && git checkout "${LATEXINDENT_VERSION}" && echo "Y" | perl latexindent-module-installer.pl
 
 WORKDIR /latexindent.pl/build
 


### PR DESCRIPTION
I have tested out in a linux runner.
```
$ docker buildx build --build-arg LATEXINDENT_VERSION=V3.23 --tag ghcr.io/cmhughes/latexindent.pl:3.23 --tag ghcr.io/cmhughes/latexindent.pl:latest .
[+] Building 22.0s (11/11) FINISHED                                                                                                                                              docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                       0.0s
 => => transferring dockerfile: 1.16kB                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/perl:5.38.0-slim-threaded-buster                                                                                                        0.6s
 => [1/9] FROM docker.io/library/perl:5.38.0-slim-threaded-buster@sha256:568de3006cfdc1844a733739cb7db5c66d52d65ea4d531cf20484a81fa818332                                                  0.0s
 => CACHED [2/9] RUN apt-get update     && apt-get install     build-essential     ca-certificates     cmake     git     wget     -y -qq --no-install-recommends     && apt-get clean      0.0s
 => CACHED [3/9] RUN git clone --depth 7 https://github.com/cmhughes/latexindent.pl                                                                                                        0.0s
 => CACHED [4/9] WORKDIR /latexindent.pl/helper-scripts                                                                                                                                    0.0s
 => [5/9] RUN git fetch --tags && git checkout "V3.23" && echo "Y" | perl latexindent-module-installer.pl                                                                                 18.1s
 => [6/9] WORKDIR /latexindent.pl/build                                                                                                                                                    0.0s 
 => [7/9] RUN cmake ../path-helper-files && make install && ln -s /usr/local/bin/latexindent.pl /usr/local/bin/latexindent                                                                 0.8s 
 => exporting to image                                                                                                                                                                     2.5s 
 => => exporting layers                                                                                                                                                                    2.5s 
 => => writing image sha256:6989e1f180683dfb34460b40e7b1c2b350961589f167600d1acc17ebda613035                                                                                               0.0s 
 => => naming to ghcr.io/cmhughes/latexindent.pl:3.23                                                                                                                                      0.0s 
 => => naming to ghcr.io/cmhughes/latexindent.pl:latest                                                                                                                                    0.0s
```

fixes #468 

cc @cmhughes 