### PR TITLE
Specify target tag when cloning repo with `docker build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,11 @@ RUN apt-get update \
 
 WORKDIR /
 
-RUN git clone --depth 7 https://github.com/cmhughes/latexindent.pl
+RUN git clone --depth 1 https://github.com/cmhughes/latexindent.pl --branch "${LATEXINDENT_VERSION}"
 
 WORKDIR /latexindent.pl/helper-scripts
 
-RUN git fetch --tags && git checkout "${LATEXINDENT_VERSION}" && echo "Y" | perl latexindent-module-installer.pl
+RUN echo "Y" | perl latexindent-module-installer.pl
 
 WORKDIR /latexindent.pl/build
 


### PR DESCRIPTION
what is this pull request about?
-
fixes #468

does this relate to an existing issue?
-
#468

does this change any existing behaviour?
-
no

what does this add?
-
- Clone repo's specific tag commit as a HEAD while building docker image.

how do I test this?
-
Run `docker build -t latexindent-test .`

```shellsession

```

anything else?
-

I'm so sorry for my slow response for https://github.com/cmhughes/latexindent.pl/issues/468#issuecomment-1712725783
