### PR TITLE
Add missing ams math environments to defaultSettings

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -185,12 +185,14 @@ lookForAlignDelims:
    alignat: 1
    alignat*: 1
    aligned: 1
+   alignedat: 1
    bmatrix: 1
    Bmatrix: 1
    cases: 1
    flalign: 1
    flalign*: 1
    pmatrix: 1
+   split: 1
    vmatrix: 1
    Vmatrix: 1
    # mathtools


### PR DESCRIPTION
The standard environments alignedat and split from the amsmath package are missing from the field lookForAlignDelims in the default settings (they both use delimiters, just like alignat, aligned, etc., so they belong there).