### PR TITLE
Add an example to the documentation for algorithm's indentation

### DIFF
--- a/documentation/demonstrations/algo.yaml
+++ b/documentation/demonstrations/algo.yaml
@@ -1,0 +1,52 @@
+specialBeginEnd:
+  ForStatement:
+    begin: \\For\{[^}]+?\}
+    end: \\EndFor
+    lookForThis: 1
+  FORStatement:
+    begin: \\FOR\{[^}]+?\}
+    end: \\ENDFOR
+    lookForThis: 1
+  WhileStatement:
+    begin: \\While\{[^}]+?\}
+    end: \\EndWhile
+    lookForThis: 1
+  WHILEStatement:
+    begin: \\WHILE\{[^}]+?\}
+    end: \\ENDWHILE
+    lookForThis: 1
+  ForAllStatement:
+    begin: \\ForAll\{[^}]+?\}
+    end: \\EndFor
+    lookForThis: 1
+  LoopStatement:
+    begin: \\Loop
+    end: \\EndLoop
+    lookForThis: 1
+  RepeatStatement:
+    begin: \\Repeat
+    end: \\Until\{[^}]+?\}
+    lookForThis: 1
+  ProcedureStatement:
+    begin: \\Procedure\{[^}]+?\}\{[^}]+?\}
+    end: \\EndProcedure
+    lookForThis: 1
+  FunctionStatement:
+    begin: \\Function\{[^}]+?\}\{[^}]+?\}
+    end: \\EndFunction
+    lookForThis: 1
+  IfStatement:
+    begin: \\If\{[^}]+?\}
+    middle:
+      - \\Else
+      - \\ElsIf\{[^}]+?\}
+    end: \\EndIf
+    lookForThis: 1
+  IFStatement:
+    begin: \\IF\{[^}]+?\}
+    middle:
+      - \\ELSE
+      - \\ELSIF\{[^}]+?\}
+    end: \\ENDIF
+    lookForThis: 1
+  specialBeforeCommand: 1

--- a/documentation/demonstrations/specialAlgo-mod1.tex
+++ b/documentation/demonstrations/specialAlgo-mod1.tex
@@ -1,0 +1,57 @@
+\begin{algorithm}[ht]
+	\caption{some caption.}
+	\begin{algorithmic}[1]
+		\Require{aaa}
+		\Ensure{bbb}
+
+		\For{$n = 1, \dots, 10$}
+			\State body
+		\EndFor
+
+		\FOR{for 1}
+			\FOR{for 2}
+				\FOR{for 3}
+					\STATE{some statement.}
+				\ENDFOR
+			\ENDFOR
+		\ENDFOR
+
+		\If{$quality\ge 9$}
+			\State $a\gets perfect$
+		\ElsIf{$quality\ge 7$}
+			\State $a\gets good$
+		\ElsIf{$quality\ge 5$}
+			\State $a\gets medium$
+		\ElsIf{$quality\ge 3$}
+			\State $a\gets bad$
+		\Else
+			\While{$i\le n$}
+				\State $sum\gets sum+i$
+				\State $i\gets i+1$
+			\EndWhile
+		\EndIf
+
+		\ForAll{$n \in \{1, \dots, 10\}$}
+			\State body
+			\Loop
+				\State body
+			\EndLoop
+			\State $sum\gets 0$
+			\State $i\gets 1$
+			\Repeat
+				\State $sum\gets sum+i$
+				\State $i\gets i+1$
+			\Until{$i>n$}
+		\EndFor
+
+		\Function{Euclid}{$a,b$}\Comment{The g.c.d. of a and b}
+			\State $r\gets a\bmod b$
+			\While{$r\not=0$}\Comment{We have the answer if r is 0}
+				\State $a\gets b$
+				\State $b\gets r$
+				\State $r\gets a\bmod b$
+			\EndWhile
+			\State \textbf{return} $b$\Comment{The gcd is b}
+		\EndFunction
+	\end{algorithmic}
+\end{algorithm}

--- a/documentation/demonstrations/specialAlgo.tex
+++ b/documentation/demonstrations/specialAlgo.tex
@@ -1,0 +1,57 @@
+\begin{algorithm}[ht]
+\caption{some caption.}
+\begin{algorithmic}[1]
+\Require{aaa}
+\Ensure{bbb}
+
+\For{$n = 1, \dots, 10$}
+\State body
+\EndFor
+
+\FOR{for 1}
+\FOR{for 2}
+\FOR{for 3}
+\STATE{some statement.}
+\ENDFOR
+\ENDFOR
+\ENDFOR
+
+\If{$quality\ge 9$}
+\State $a\gets perfect$
+\ElsIf{$quality\ge 7$}
+\State $a\gets good$
+\ElsIf{$quality\ge 5$}
+\State $a\gets medium$
+\ElsIf{$quality\ge 3$}
+\State $a\gets bad$
+\Else
+\While{$i\le n$}
+\State $sum\gets sum+i$
+\State $i\gets i+1$
+\EndWhile
+\EndIf
+
+\ForAll{$n \in \{1, \dots, 10\}$}
+\State body
+\Loop
+\State body
+\EndLoop
+\State $sum\gets 0$
+\State $i\gets 1$
+\Repeat
+\State $sum\gets sum+i$
+\State $i\gets i+1$
+\Until{$i>n$}
+\EndFor
+
+\Function{Euclid}{$a,b$}\Comment{The g.c.d. of a and b}
+\State $r\gets a\bmod b$
+\While{$r\not=0$}\Comment{We have the answer if r is 0}
+\State $a\gets b$
+\State $b\gets r$
+\State $r\gets a\bmod b$
+\EndWhile
+\State \textbf{return} $b$\Comment{The gcd is b}
+\EndFunction
+\end{algorithmic}
+\end{algorithm}

--- a/documentation/sec-default-user-local.rst
+++ b/documentation/sec-default-user-local.rst
@@ -1447,7 +1447,7 @@ There are examples in which it is advantageous to search for ``specialBeginEnd``
 	
 
 
-You can,optionally, specify the ``middle`` field for anything that you specify in ``specialBeginEnd``.
+You can, optionally, specify the ``middle`` field for anything that you specify in ``specialBeginEnd``.
 
 .. proof:example::	
 	
@@ -1501,6 +1501,44 @@ You can,optionally, specify the ``middle`` field for anything that you specify i
 	-  the ``Else`` statement has *not* been indented appropriately in :numref:`lst:special2-mod1` – read on!
 	
 	-  we have specified multiple settings for the ``middle`` field using the syntax demonstrated in :numref:`lst:middle1-yaml` so that the body of the ``Else`` statement has been indented appropriately in :numref:`lst:special2-mod2`.
+	
+
+
+You may need these fields in your own YAML files (see :numref:`sec:noadd-indent-rules`), if you use popular algorithm packages such as algorithms, algorithm2e or algpseudocode, etc.
+
+.. proof:example::	
+	
+	For example, let’s consider the ``.tex`` file in :numref:`lst:specialAlgo`.
+	
+	.. index:: specialBeginEnd;middle
+	
+	.. index:: specialBeginEnd;Algorithms example
+	
+	.. literalinclude:: demonstrations/specialAlgo.tex
+		:class: .tex
+		:caption: ``specialAlgo.tex`` 
+		:name: lst:specialAlgo
+	
+	Upon saving the YAML settings in :numref:`lst:algo-yaml` and running the command
+	
+	.. index:: switches;-l demonstration
+	
+	.. code-block:: latex
+	   :class: .commandshell
+	
+	   latexindent.pl specialAlgo.tex -l=algo
+	
+	then we obtain the output given in :numref:`lst:specialAlgo-mod1`.
+	
+	.. literalinclude:: demonstrations/specialAlgo-mod1.tex
+		:class: .tex
+		:caption: ``specialAlgo.tex`` using :numref:`lst:algo-yaml` 
+		:name: lst:specialAlgo-mod1
+	
+	.. literalinclude:: demonstrations/algo.yaml
+		:class: .baseyaml
+		:caption: ``algo.yaml`` 
+		:name: lst:algo-yaml
 	
 
 

--- a/documentation/sec-default-user-local.tex
+++ b/documentation/sec-default-user-local.tex
@@ -1218,7 +1218,7 @@ latexindent.pl specialLR.tex -l=specialsLeftRight.yaml,specialBeforeCommand.yaml
  \end{itemize}
  \end{example}
 
- You can,optionally, specify \announce{2018-04-27}{update to specialBeginEnd} the
+ You can, optionally, specify \announce{2018-04-27}{update to specialBeginEnd} the
  \texttt{middle} field for anything that you specify in \texttt{specialBeginEnd}.
 
  \begin{example}
@@ -1258,6 +1258,29 @@ latexindent.pl special2.tex -l=middle1
         \texttt{Else} statement has been indented appropriately in
         \cref{lst:special2-mod2}.
  \end{itemize}
+ \end{example}
+
+ You may need these fields in your own YAML files (see \vref{sec:localsettings}), if you use popular algorithm packages such as algorithms, algorithm2e or algpseudocode, etc.
+
+ \begin{example}
+ For example, let’s consider the \texttt{.tex} file in \cref{lst:specialAlgo}.
+ \index{specialBeginEnd!middle} \index{specialBeginEnd!Algorithms example}
+
+ \cmhlistingsfromfile{demonstrations/specialAlgo.tex}{\texttt{specialAlgo.tex}}{lst:specialAlgo}
+
+ Upon saving the YAML settings in \cref{lst:algo-yaml} and running the command
+ \index{switches!-l demonstration}
+
+ \begin{commandshell}
+latexindent.pl specialAlgo.tex -l=algo
+ \end{commandshell}
+
+ then we obtain the output given in \cref{lst:specialAlgo-mod1}.
+
+ \begin{cmhtcbraster}
+  \cmhlistingsfromfile{demonstrations/specialAlgo-mod1.tex}{\texttt{specialAlgo.tex} using \cref{lst:algo-yaml}}{lst:specialAlgo-mod1}
+  \cmhlistingsfromfile[style=yaml-LST]{demonstrations/algo.yaml}[yaml-TCB]{\texttt{algo.yaml}}{lst:algo-yaml}
+ \end{cmhtcbraster}
  \end{example}
 
  You may \announce{2018-08-13}{specialBeginEnd verbatim} specify fields in


### PR DESCRIPTION
what is this pull request about?
-
*This pull request adds an example to the documentation for illustrating the support of `latexindent.pl` for algorithm packages, such as algorithmic and algpseudocodex*

does this relate to an existing issue?
-
*Here is the link: [issue 427](https://github.com/cmhughes/latexindent.pl/issues/427)*

does this change any existing behaviour?
-
*no*

what does this add?
-
This will add files `documentation/demonstrations/specialAlgo.tex`, `documentation/demonstrations/specialAlgo-mod1.tex` and 
`documentation/demonstrations/algo.yaml` to illustrate an example for `algorithm` environment indentation.
Correspondingly, `documentation/sec-default-user-local.rst` and `documentation/sec-default-user-local.tex` are changed for online and PDF documentation.

how do I test this?
-
*You can check the details in `documentation/sec-default-user-local.rst` and `documentation/sec-default-user-local.tex`*
