### PR TITLE
Update install guide for Arch-based distros

### DIFF
--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -114,20 +114,15 @@ sudo apt install texlive-extra-utils
    \index{latexindent-linux} \index{linux} \index{TeXLive}
 
   \paragraph{Arch-based distributions}
-   First install the dependencies
-
+   \texttt{latexindent} is included in Arch-packaged TeX Live, and can be installed by:
    \begin{commandshell}
-sudo pacman -S perl cpanminus
+sudo pacman -S texlive-binextra perl-yaml-tiny perl-file-homedir
 \end{commandshell}
 
-   In addition, install \texttt{perl-file-homedir} from AUR, using your AUR helper of
-   choice,
-
+   To enable optional \texttt{--GCString} switch, install \texttt{perl-unicode-linebreak}:
    \begin{commandshell}
-sudo paru -S perl-file-homedir
+sudo pacman -S perl-unicode-linebreak
 \end{commandshell}
-
-   then run the latexindent-module-installer.pl file located at helper-scripts/
 
   \paragraph{Alpine}
    If you are using Alpine, some \texttt{Perl} modules are not build-compatible with


### PR DESCRIPTION
what is this pull request about?
-
Current Arch-based install guide is out-of-dated and vague, and this pr update more details.
* Users can install `perl-file-homedir` directly by `pacman` now.
* Add `perl-yaml-tiny` as a dependency, which can be confirm by:
  * https://github.com/cmhughes/latexindent.pl/issues/404#issuecomment-1915504440)
  * https://wiki.archlinux.org/title/TeX_Live#Arch-packaged_TeX_Live
* Add `perl-unicode-linebreak` as a optional dependency to provide `Unicode::GCString` module.


does this relate to an existing issue?
-
https://github.com/cmhughes/latexindent.pl/issues/404#issuecomment-1915504440 mentioned a broken install via pacman following the current documentation.

