### PR TITLE
Fix typo for fineTuning:trailingComments:notPrecededBy

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -649,7 +649,7 @@ fineTuning:
     before: (?:#\d\h*;?,?\/?)+|\<.*?\>
     between: _|\^|\*
   trailingComments:
-    notPreceededBy: (?<!\\)
+    notPrecededBy: (?<!\\)
     afterComment: .*?
   modifyLineBreaks:
     doubleBackSlash: \\\\(?:\h*\[\h*\d+\h*[a-zA-Z]+\h*\])?

--- a/documentation/demonstrations/fine-tuning3.yaml
+++ b/documentation/demonstrations/fine-tuning3.yaml
@@ -1,6 +1,6 @@
 fineTuning:
     trailingComments:
-      notPreceededBy: (?<!\\)
+      notPrecededBy: (?<!\\)
       afterComment: (?!(?:\hend)).*?
 
 specialBeginEnd:

--- a/documentation/demonstrations/href2.yaml
+++ b/documentation/demonstrations/href2.yaml
@@ -1,6 +1,6 @@
 fineTuning:
     trailingComments:
-      notPreceededBy: '(?:(?<!Handbook)(?<!for)(?<!Spoken))'
+      notPrecededBy: '(?:(?<!Handbook)(?<!for)(?<!Spoken))'
 
 modifyLineBreaks:
     textWrapOptions:

--- a/documentation/latexindent-yaml-schema.json
+++ b/documentation/latexindent-yaml-schema.json
@@ -1496,9 +1496,14 @@
           "description": "fine tuning, for trailing comments",
           "type": "object",
           "properties": {
-            "notPreceededBy": {
+            "notPrecededBy": {
               "description": "regular expression for what can NOT come before %, for example \\%",
               "type": "string"
+            },
+            "notPreceededBy": {
+              "description": "please use notPrecededBy instead",
+              "type": "string",
+              "deprecated": true
             },
             "afterComment": {
               "description": "regular expression for what can come after %",

--- a/test-cases/fine-tuning/href2.yaml
+++ b/test-cases/fine-tuning/href2.yaml
@@ -1,6 +1,6 @@
 fineTuning:
     trailingComments:
-      notPreceededBy: '(?:(?<!Handbook)(?<!for)(?<!Spoken))'
+      notPrecededBy: '(?:(?<!Handbook)(?<!for)(?<!Spoken))'
 
 modifyLineBreaks:
     textWrapOptions:

--- a/test-cases/specials/issue-448b.yaml
+++ b/test-cases/specials/issue-448b.yaml
@@ -8,5 +8,5 @@ specialBeginEnd:
 
 fineTuning:
     trailingComments:
-      notPreceededBy: (?<!\\)
+      notPrecededBy: (?<!\\)
       afterComment: (?!(?:\hend)).*?


### PR DESCRIPTION
what is this pull request about?
-
Fixed `notPreceededBy` to `notPrecededBy`. Similar typos in comments and docs were fixed in #410, but still remained in code.

does this relate to an existing issue?
-
No.

does this change any existing behaviour?
-
Yes.

what does this add?
-
I have made changes with reference to [this commit](https://github.com/cmhughes/latexindent.pl/commit/d4402714f01a78286a5df68f3493c2d5e2a9c5d5). For backward compatibility, the old name can still be used, but a warning message will be issued.

Also updated the JSON Schema file accordingly, with the old name deprecated.

anything else?
-
I am not very familiar with Perl, so I would apologize for any rudimentary mistakes.
