### PR TITLE
bugfix for Incorrect encoding

### DIFF
--- a/LatexIndent/GetYamlSettings.pm
+++ b/LatexIndent/GetYamlSettings.pm
@@ -389,36 +389,8 @@ sub yaml_read_settings {
                 # output the contents of indentconfig to the log file
                 $logger->info( Dump \%{ $userSettings->[0] } );
 
-                # change the encoding of the paths according to the field `encoding`
-                if ( $userSettings and ( ref( $userSettings->[0] ) eq 'HASH' ) and $userSettings->[0]->{encoding} ) {
-                    use Encode;
-                    my $encoding       = $userSettings->[0]->{encoding};
-                    my $encodingObject = find_encoding($encoding);
-
-                    # Check if the encoding is valid.
-                    if ( ref($encodingObject) ) {
-                        $logger->info("*Encoding of the paths is $encoding");
-                        foreach ( @{ $userSettings->[0]->{paths} } ) {
-                            my $temp = $encodingObject->encode("$_");
-                            $logger->info("Transform file encoding: $_ -> $temp");
-                            push( @absPaths, $temp );
-                        }
-                    }
-                    else {
-                        $logger->warn("*encoding \"$encoding\" not found");
-                        $logger->warn("Ignore this setting and will take the default encoding.");
-                        @absPaths = @{ $userSettings->[0]->{paths} };
-                        foreach ( @{ $userSettings->[0]->{paths} } ) {
-                            push( @absPaths, $_ );
-                        }
-                    }
-                }
-                else    # No such setting, and will take the default
-                {
-                    # $logger->info("*Encoding of the paths takes the default.");
-                    foreach ( @{ $userSettings->[0]->{paths} } ) {
-                        push( @absPaths, $_ );
-                    }
+                foreach ( @{ $userSettings->[0]->{paths} } ) {
+                    push( @absPaths, $_ );
                 }
             }
 

--- a/documentation/sec-appendices.tex
+++ b/documentation/sec-appendices.tex
@@ -922,21 +922,26 @@ TRACE: Searching myenv for optional and mandatory arguments
   and \lstinline!-----! respectively.
   \end{example}
 
- \section{Encoding indentconfig.yaml}\label{app:encoding}
-  In relation to \vref{sec:indentconfig}, Windows users that encounter encoding issues
-  with \texttt{indentconfig.yaml}, may wish to run the following command in either
-  \texttt{cmd.exe} or \texttt{powershell.exe}:
-  \begin{dosprompt}
-chcp
-    \end{dosprompt}
-  They may receive the following result
-  \begin{dosprompt}
-Active code page: 936
-    \end{dosprompt}
-  and can then use the settings given in \cref{lst:indentconfig-encoding1} within their
-  \texttt{indentconfig.yaml}, where 936 is the result of the \texttt{chcp} command.
+ \section{Encoding}\label{app:encoding}
+ 
+ When using latexindent in different ways on different systems, the range of characters supported by its switches/flags/options (see \vref{sec:commandline} )  may vary.
 
-  \cmhlistingsfromfile[style=yaml-LST]{demonstrations/encoding1.yaml}[yaml-TCB]{\texttt{encoding} demonstration for \texttt{indentconfig.yaml}}{lst:indentconfig-encoding1}
+ For the Windows executable file \texttt{latexindent.exe}, its options support UTF-8 characters.
+
+ For the Windows Perl script \texttt{latexindent.pl}, its option switch supports the characters supported by the encoding corresponding to the system code page. You can check the system code page by running the following command in either \texttt{cmd.exe} or \texttt{powershell.exe}:
+  \begin{dosprompt}
+  chcp
+  \end{dosprompt}
+  which may receive the following result
+  \begin{dosprompt}
+  Active code page: 936
+  \end{dosprompt}
+ and then the characters supported by the code page can be found in \href{Microsoft's code page identifier table}{https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers}.
+ For example, the characters supported by the encoding corresponding to code page 936 are: ANSI/OEM Simplified Chinese (PRC, Singapore); Chinese Simplified (GB2312).
+
+ For Ubuntu Linux and macOS users, whether using the Perl script or the executable file, the options support UTF-8 characters.
+
+
 
  \section{dos2unix linebreak adjustment}
 

--- a/documentation/sec-how-to-use.tex
+++ b/documentation/sec-how-to-use.tex
@@ -65,6 +65,9 @@
  written to \texttt{indent.log}, but other additional information will be written
  depending on which of the following options are used.
 
+  When using \texttt{latexindent.pl} in different ways on different systems, the range of characters supported by its switches/flags/options may vary. 
+  We discuss these in Section \cref{app:encoding}.
+  
 \flagbox{-v, --version}
  \index{switches!-v, --version definition and details}
  \announce{2017-06-25}{version}

--- a/documentation/sec-indent-config-and-settings.tex
+++ b/documentation/sec-indent-config-and-settings.tex
@@ -69,16 +69,6 @@
  \texttt{latexindent.yaml} and friends settings files. This can lead to creative nesting
  of configuration files; a demonstration is given in \vref{sec:appendix:paths}.
 
- If you find that \announce{2021-06-19}{encoding option for indentconfig.yaml}
- \texttt{latexindent.pl} does not read your YAML file, then it might be as a result of
- the default commandline encoding not being UTF-8; normally this will only occur for
- Windows users. In this case, you might like to explore the \texttt{encoding} option for
- \texttt{indentconfig.yaml} as demonstrated in \cref{lst:indentconfig-encoding}.%
-
- \cmhlistingsfromfile[style=yaml-LST]{demonstrations/encoding.yaml}[yaml-TCB]{The \texttt{encoding} option for \texttt{indentconfig.yaml}}{lst:indentconfig-encoding}
-
- Thank you to \cite{qiancy98} for this contribution; please see \vref{app:encoding} and
- details within \cite{encoding} for further information.
 
 \subsection{localSettings.yaml and friends}\label{sec:localsettings}
  The \texttt{-l} switch tells \texttt{latexindent.pl} to look for

--- a/documentation/sec-introduction.tex
+++ b/documentation/sec-introduction.tex
@@ -53,6 +53,8 @@
  throughout this document for details}.
 
 \subsection{Quick start}\label{sec:quickstart}
+ When \texttt{latexindent.pl} reading and writing files, the files are read and written in UTF-8 format by default. That is to say, the encoding format for tex and yaml files needs to be in UTF-8 format.
+
  If you'd like to get started with \texttt{latexindent.pl} then simply type
 
  \begin{commandshell}


### PR DESCRIPTION
what is this pull request about?
-
fix for Incorrect encoding (possiblely due to #505)

does this relate to an existing issue?
-
https://github.com/cmhughes/latexindent.pl/issues/547

does this change any existing behaviour?
-
yes

what does this add?
-
Use Windows:: GetACP() to obtain the code page of the Windows system, and then obtain the system default encoding. Users do not need to specify the encoding.

