### PR TITLE
Fix latexindent yaml schema

### DIFF
--- a/documentation/latexindent-yaml-schema.json
+++ b/documentation/latexindent-yaml-schema.json
@@ -333,8 +333,12 @@
               "description": "regular expression containing the *beginning* part"
             },
             "middle": {
-              "type": "string",
-              "description": "optional: regular expression containing the *middle* part"
+              "type": ["string", "array"],
+              "description": "optional: one or more regular expressions for the *middle* part",
+              "items": {
+                "description": "regular expression for the *middle* part",
+                "type": "string"
+              }
             },
             "end": {
               "type": "string",

--- a/documentation/latexindent-yaml-schema.json
+++ b/documentation/latexindent-yaml-schema.json
@@ -324,7 +324,7 @@
         }
       },
       "patternProperties": {
-        ".*": {
+        "^(?!specialBeforeCommand$).*": {
           "description": "name of special code block",
           "type": "object",
           "properties": {
@@ -893,7 +893,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(BeginStartsOnOwnLine|BodyStartsOnOwnLine|EndStartsOnOwnLine|EndFinishesWithLineBreak)$).*": {
               "description": "poly-switches for environments (PER-NAME)",
               "type": "object",
               "properties": {
@@ -947,7 +947,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(SpecialBeginStartsOnOwnLine|SpecialBodyStartsOnOwnLine|SpecialEndStartsOnOwnLine|SpecialEndFinishesWithLineBreak)$).*": {
               "description": "poly-switches for specialBeginEnd (PER-NAME)",
               "type": "object",
               "properties": {
@@ -996,7 +996,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(KeyStartsOnOwnLine|EqualsStartsOnOwnLine|EqualsFinishesWithLineBreak)$).*": {
               "description": "poly-switches for key equals value (PER-NAME)",
               "type": "object",
               "properties": {
@@ -1065,7 +1065,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(IfStartsOnOwnLine|BodyStartsOnOwnLine|OrStartsOnOwnLine|OrFinishesWithLineBreak|ElseStartsOnOwnLine|ElseFinishesWithLineBreak|FiStartsOnOwnLine|FiFinishesWithLineBreak)$).*": {
               "description": "poly-switches for ifElseFi (PER-NAME)",
               "type": "object",
               "properties": {
@@ -1129,7 +1129,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(CommandStartsOnOwnLine|CommandNameFinishesWithLineBreak)$).*": {
               "description": "poly-switches for commands (PER-NAME)",
               "type": "object",
               "properties": {
@@ -1163,7 +1163,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(VerbatimBeginStartsOnOwnLine|VerbatimEndFinishesWithLineBreak)$).*": {
               "description": "poly-switches for verbatim (PER-NAME)",
               "type": "object",
               "properties": {
@@ -1197,7 +1197,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(NameStartsOnOwnLine|NameFinishesWithLineBreak)$).*": {
               "description": "poly-switches for commands (PER-NAME)",
               "type": "object",
               "properties": {
@@ -1231,7 +1231,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(ItemStartsOnOwnLine|ItemFinishesWithLineBreak)$).*": {
               "description": "poly-switches for items (PER-NAME)",
               "type": "object",
               "properties": {
@@ -1275,7 +1275,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(LSqBStartsOnOwnLine|OptArgBodyStartsOnOwnLine|RSqBStartsOnOwnLine|RSqBFinishesWithLineBreak)$).*": {
               "description": "poly-switches for optional arguments (PER-NAME)",
               "type": "object",
               "properties": {
@@ -1329,7 +1329,7 @@
             }
           },
           "patternProperties": {
-            ".*": {
+            "^(?!(LCuBStartsOnOwnLine|MandArgBodyStartsOnOwnLine|RCuBStartsOnOwnLine|RCuBFinishesWithLineBreak)$).*": {
               "description": "poly-switches for mandatory arguments (PER-NAME)",
               "type": "object",
               "properties": {


### PR DESCRIPTION
what is this pull request about?
-
This PR fixes several issues in the [YAML schema](https://github.com/cmhughes/latexindent.pl/blob/main/documentation/latexindent-yaml-schema.json) for `latexindent`.

### Conflict between `patternProperties` and `properties`

In the original schema, `properties` and `patternProperties` conflict in several places. For instance, the `specialBeginEnd` object contains the integer-valued `specialBeforeCommand` property and an object-valued pattern property defined by
the universal matcher (`.*`). This causes a conflict where the `specialBeforeCommand` property matches both `properties` and `patternProperties`. As a result, YAML schema validators throw an error stating that `specialBeforeCommand` should be an object but is an integer.

The likely intent of the current schema was for `patternProperties` not to match fields explicitly defined in `properties`. However, according to the JSON Schema specification, a property can match both simultaneously. This behavior is
discussed in:

- https://github.com/json-schema-org/json-schema-spec/issues/76
- https://github.com/jsonrainbow/json-schema/issues/705

### Wrong specification for `specialBeginEnd.*.middle`

The schema incorrectly specifies `specialBeginEnd.*.middle` as a `string`. According to the documentation (Listings 149 and 152 at `main@78d452f`), it can also be an `array` of `string`s.

does this relate to an existing issue?
-
No

does this change any existing behaviour?
-
Yes, it fixes the schema's incorrect specifications.

what does this add?
-

### Fix 1: Resolve conflict between `patternProperties` and `properties`

To resolve the conflict, each universal matcher in problematic `patternProperties` fields is restricted to exclude fields listed in `properties`. For example:

- Change `specialBeginEnd.patternProperties` from `.*` to `^(?!specialBeforeCommand$).*`, which matches everything except `specialBeforeCommand`.

- Similarly, update `modifyLineBreaks.commands.patternProperties` from `.*` to `^(?!CommandStartsOnOwnLine|CommandNameFinishesWithLineBreak)$).*`.

Although not an elegant solution, this seems to be the best approach under the current JSON Schema limitations.

### Fix 2: Correct specification for `specialBeginEnd.*.middle`

The type of `specialBeginEnd.*.middle` is updated from `string` to `["string", "array"]`, with additional validation for array items to be strings. Minor modifications to the `description` field are also made.

how do I test this?
-

Use the following configuration to test the schema:

```yaml
---
# latexindent.yaml
defaultIndent: "  "

specialBeginEnd:
  specialBeforeCommand: 1

  If:
    begin: \\If
    middle: \\ElsIf
    end: \\EndIf

  IfStatement:
    begin: \\If\{[^}]+?\}
    middle:
      - \\Else
      - \\ElsIf\{[^}]+?\}
    end: \\EndIf

```

To validate this YAML file:

1. Install [`check-jsonschema`](https://github.com/python-jsonschema/check-jsonschema), a simple Python utility for validating files against JSON/YAML schemas:

   ```shell
   pipx install check-jsonschema
   ```

1. Run the validation command using the current schema:

   ```shell
   check-jsonschema latexindent.yaml --schemafile https://raw.githubusercontent.com/cmhughes/latexindent.pl/main/documentation/latexindent-yaml-schema.json
   ```

   Expected output (errors):

   ```
   Schema validation errors were encountered.
     latexindent.yaml::$.specialBeginEnd.specialBeforeCommand: 1 is not of type 'object'
     latexindent.yaml::$.specialBeginEnd.IfStatement.middle: ['\\\\Else', '\\\\ElsIf\\{[^}]+?\\}'] is not of type 'string'
   ```

1. Test with the new schema from this PR:

   ```shell
   check-jsonschema latexindent.yaml --schemafile https://raw.githubusercontent.com/arodomanov/latexindent.pl/refs/heads/fix-latexindent-yaml-schema/documentation/latexindent-yaml-schema.json
   ```

   Expected output (no errors):

   ```
   ok -- validation done
   ```
