### PR TITLE
Implement arm64 support

### DIFF
--- a/.github/workflows/build-documentation-and-executables.yaml
+++ b/.github/workflows/build-documentation-and-executables.yaml
@@ -118,7 +118,7 @@ jobs:
           path: target/release
   #-------------------------------------------------------------------------
   #
-  # 3. Linux latexindent
+  # 3.1. Linux x86_64 latexindent
   #
   build-linux-executable:
     name: 'create Linux executable latexindent'
@@ -170,6 +170,61 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: latexindent-linux
+          path: target/release
+  #-------------------------------------------------------------------------
+  #
+  # 3.1. Linux arm64 latexindent
+  #
+  build-linux-arm64-executable:
+    name: 'create Linux arm64 executable latexindent'
+    runs-on: 'ubuntu-22.04-arm'
+    steps:
+      #
+      # checkout github.com/cmhughes/latexindent.pl
+      # https://github.com/actions/checkout
+      #
+      - name: load the "base actions/checkout" so as to access latexindent.pl
+        uses: actions/checkout@v4
+      #
+      # https://github.com/marketplace/actions/setup-perl-environment
+      #
+      - name: install Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: 'latest'
+      - name: install Perl modules using cpan
+        run: |
+          cpanm -f PAR::Packer
+          cpanm YAML::Tiny
+          cpanm File::HomeDir
+          cpanm Unicode::GCString
+      - name: preparations for PAR packer
+        run: |
+          sed -i'.bak' -r 's,eval\s\"use\sUnicode::GCString\"\sif\s\$switches\{GCString\},use Unicode::GCString,' latexindent.pl
+      #
+      # https://metacpan.org/pod/pp
+      # https://github.com/plk/biber/blob/dev/dist/linux-musl_x86_64/build.sh
+      #
+      - name: create Linux executable latexindent using PAR Packer
+        run: |
+          export PAR_VERBATIM=1
+          pp --addfile="defaultSettings.yaml;lib/LatexIndent/defaultSettings.yaml" --cachedeps=scancache --output latexindent-linux-arm64 latexindent.pl
+      - name: move Linux latexindent to release directory
+        run: |
+          mkdir -p target/release
+          mv latexindent-linux-arm64 target/release
+      - name: tiny test of latexindent from release directory
+        run: |
+          cd target/release 
+          ./latexindent-linux-arm64 --help
+          ./latexindent-linux-arm64 ../../test-cases/environments/environments-simple-nested.tex
+      #
+      # https://stackoverflow.com/questions/57498605/github-actions-share-workspace-artifacts-between-jobs
+      #
+      - name: upload latexindent-linux-arm64 as artifact for zipping
+        uses: actions/upload-artifact@master
+        with:
+          name: latexindent-linux-arm64
           path: target/release
   #-------------------------------------------------------------------------
   #
@@ -232,7 +287,7 @@ jobs:
   #
   zip-files:
     name: 'create latexindent.zip'
-    needs: [build-latexindent-doc-pdf, build-windows-exe, build-linux-executable, build-macos-executable]
+    needs: [build-latexindent-doc-pdf, build-windows-exe, build-linux-executable, build-linux-arm64-executable, build-macos-executable]
     runs-on: ubuntu-latest
     steps:
       - name: Loading the "base actions/checkout" so as to access the repository latexindent.pl
@@ -248,6 +303,7 @@ jobs:
           mkdir latexindent/bin/
           mkdir latexindent/bin/windows
           mkdir latexindent/bin/linux
+          mkdir latexindent/bin/linux-arm64
           mkdir latexindent/bin/macos
       - name: copy documentation files from repository into temporary folder
         run: |
@@ -281,6 +337,11 @@ jobs:
         with:
           name: latexindent-linux
           path: latexindent/bin/linux
+      - name: download Linux arm64 executable latexindent 
+        uses: actions/download-artifact@master
+        with:
+          name: latexindent-linux-arm64
+          path: latexindent/bin/linux-arm64
       - name: download MacOS executable latexindent 
         uses: actions/download-artifact@master
         with:
@@ -297,6 +358,7 @@ jobs:
       - name: create latexindent.zip
         run: |
           mv latexindent/bin/linux/latexindent-linux latexindent/bin/linux/latexindent
+          mv latexindent/bin/linux-arm64/latexindent-linux-arm64 latexindent/bin/linux-arm64/latexindent
           mv latexindent/bin/macos/latexindent-macos latexindent/bin/macos/latexindent
           zip -r latexindent.zip latexindent/
           mkdir -p target/release
@@ -333,6 +395,11 @@ jobs:
         with:
           name: latexindent-linux
           path: for-release
+      - name: download Linux arm64 executable latexindent 
+        uses: actions/download-artifact@master
+        with:
+          name: latexindent-linux-arm64
+          path: for-release
       - name: download MacOS executable latexindent 
         uses: actions/download-artifact@master
         with:
@@ -360,6 +427,7 @@ jobs:
             for-release/latexindent.zip
             for-release/latexindent.exe
             for-release/latexindent-linux
+            for-release/latexindent-linux-arm64
             for-release/latexindent-macos
   #=========================================================================
   #


### PR DESCRIPTION
what is this pull request about?
-
It implements arm64 support for build CI.

does this relate to an existing issue?
-
https://github.com/cmhughes/latexindent.pl/issues/560

does this change any existing behaviour?
-
yes

what does this add?
-
It adds changes to GitHub workflow for publishing releases. Releases would now include an arm64 executable file.

how do I test this?
-
Check GitHub workflow logs and review release files. 

anything else?
-
I've tested the [workflow in my fork myself](https://github.com/life00/latexindent.pl/actions/runs/13227673679) (it only failed at the end because there was no tag, so it's fine).
