### PR TITLE
oneSentencePerLine: adjust sentencesDoNOTcontain to include end

### DIFF
--- a/defaultSettings.yaml
+++ b/defaultSettings.yaml
@@ -528,7 +528,7 @@ modifyLineBreaks:
       questionMark: 1                   # 0/1
       other: 0                          # regex
     sentencesDoNOTcontain:
-      other: \\begin                    # regex
+      other: \\begin|\\end              # regex
   textWrapOptions:
     columns: 0
     multipleSpacesToSingle: 1


### PR DESCRIPTION
regex for sentencesDoNOTcontain to include `\end`

what is this pull request about?
I would suggest adding as default the following regex for sentencesDoNOTcontain:
```yaml
    sentencesDoNOTcontain:
      other: \\begin|\\end
```
to avoid the program removing unexpectedly line breaks.

does this relate to an existing issue?
- 
#579 

does this change any existing behaviour?
-
*yes*

what does this add?
-
It changed defaultSettings.yaml

An example is reported in the related issue.

how do I test this?
-
I have already run test-case.sh and all the existing tests passed.

It should be checked that, if the body of a generic environment doesn't finish with a sentence end (for example a full stop), the text after the \end must belong to a new sentence anyway.

anything else?
-
