### PR TITLE
Update Docker base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.36.1-slim-threaded-buster
+FROM perl:5.41.13-slim-threaded-bookworm
 #
 # GitHub codespaces necessary file
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.40.0-slim-threaded-buster
+FROM perl:5.41.13-slim-threaded-bookworm
 #
 # Docker necessary file
 #
@@ -17,7 +17,7 @@ FROM perl:5.40.0-slim-threaded-buster
 #
 
 ARG LATEXINDENT_VERSION
-ENV LATEXINDENT_VERSION ${LATEXINDENT_VERSION:-V3.24.7}
+ENV LATEXINDENT_VERSION=${LATEXINDENT_VERSION:-V3.24.7}
 
 RUN apt-get update \
     && apt-get install \


### PR DESCRIPTION
what is this pull request about?
-
Fix: https://github.com/cmhughes/latexindent.pl/pull/370#issuecomment-3191246173

does this relate to an existing issue?
-
No

does this change any existing behaviour?
-
No

what does this add?
-
Update Docker base image
- old: `perl:5.36.1-slim-threaded-buster` (Dev Container) / `perl:5.40.0-slim-threaded-buster`
- new: `perl:5.41.13-slim-threaded-bookworm`

how do I test this?
-
```shellsession
❯ docker build -t latexindent .
...
 => => naming to docker.io/library/latexindent

❯ docker run --rm -it latexindent -v
3.24.7, 2025-08-15
```
